### PR TITLE
Implement cached recommendation ranking service

### DIFF
--- a/app/api/recommend/route.ts
+++ b/app/api/recommend/route.ts
@@ -1,0 +1,82 @@
+import { AlphaVantageClient } from "../../../lib/data/alphaVantage.js";
+import { AppViewsRepository } from "../../../lib/data/appViews.js";
+import { InMemoryFundamentalsRepository } from "../../../lib/data/fundamentals.js";
+import { RecommendationService } from "../../../lib/recommendation/service.js";
+
+function buildFundamentalsRepository(): InMemoryFundamentalsRepository {
+  const repo = new InMemoryFundamentalsRepository([
+    {
+      symbol: "VOO",
+      name: "Vanguard S&P 500 ETF",
+      instrumentType: "ETF",
+      expenseRatio: 0.0003,
+      distributionYield: 0.013,
+      buyScore: 82,
+      price: 420.5,
+    },
+    {
+      symbol: "QQQ",
+      name: "Invesco QQQ Trust",
+      instrumentType: "ETF",
+      expenseRatio: 0.002,
+      distributionYield: 0.009,
+      buyScore: 76,
+      price: 355.1,
+    },
+    {
+      symbol: "AAPL",
+      name: "Apple Inc.",
+      instrumentType: "EQUITY",
+      buyScore: 78,
+      price: 172.3,
+    },
+    {
+      symbol: "MSFT",
+      name: "Microsoft Corp.",
+      instrumentType: "EQUITY",
+      buyScore: 81,
+      price: 329.4,
+    },
+    {
+      symbol: "SCHD",
+      name: "Schwab U.S. Dividend Equity ETF",
+      instrumentType: "ETF",
+      expenseRatio: 0.0006,
+      distributionYield: 0.031,
+      buyScore: 75,
+      price: 73.7,
+    },
+  ]);
+
+  return repo;
+}
+
+const viewsRepository = new AppViewsRepository();
+viewsRepository.load([
+  { symbol: "AAPL", views: 1923 },
+  { symbol: "MSFT", views: 1640 },
+  { symbol: "VOO", views: 1344 },
+  { symbol: "QQQ", views: 1198 },
+  { symbol: "SCHD", views: 880 },
+]);
+
+const fundamentalsRepository = buildFundamentalsRepository();
+
+const alphaVantageClient = new AlphaVantageClient({
+  apiKey: process.env.ALPHA_VANTAGE_API_KEY ?? "demo",
+});
+
+const recommendationService = new RecommendationService({
+  alphaVantageClient,
+  appViewsRepository: viewsRepository,
+  fundamentalsRepository,
+});
+
+export async function GET(request: Request): Promise<Response> {
+  const { searchParams } = new URL(request.url);
+  const limitParam = searchParams.get("limit");
+  const limit = limitParam ? Number(limitParam) : 6;
+
+  const recommendations = await recommendationService.build(limit);
+  return Response.json(recommendations);
+}

--- a/lib/cache/ttlCache.js
+++ b/lib/cache/ttlCache.js
@@ -1,0 +1,74 @@
+/**
+ * @template TValue
+ */
+class TTLCache {
+  /**
+   * @param {number} ttlMs
+   */
+  constructor(ttlMs) {
+    this.ttlMs = ttlMs;
+    /** @type {Map<string, { value: TValue; expiresAt: number }>} */
+    this.entries = new Map();
+  }
+
+  /**
+   * @param {string} key
+   * @returns {TValue | undefined}
+   */
+  get(key) {
+    const now = Date.now();
+    const entry = this.entries.get(key);
+    if (!entry) return undefined;
+    if (entry.expiresAt <= now) {
+      this.entries.delete(key);
+      return undefined;
+    }
+    return entry.value;
+  }
+
+  /**
+   * @param {string} key
+   * @param {TValue} value
+   */
+  set(key, value) {
+    const expiresAt = Date.now() + this.ttlMs;
+    this.entries.set(key, { value, expiresAt });
+  }
+
+  /**
+   * @param {string} key
+   */
+  delete(key) {
+    this.entries.delete(key);
+  }
+
+  clear() {
+    this.entries.clear();
+  }
+}
+
+/**
+ * @template {any[]} TArgs
+ * @template TValue
+ * @param {( ...args: TArgs) => Promise<TValue> | TValue} fn
+ * @param {{ ttlMs: number; getKey?: (...args: TArgs) => string }} options
+ * @returns {( ...args: TArgs) => Promise<TValue>}
+ */
+function memoizeWithTTL(fn, options) {
+  const cache = new TTLCache(options.ttlMs);
+  const getKey = options.getKey ?? ((...args) => JSON.stringify(args));
+
+  return async (...args) => {
+    const key = getKey(...args);
+    const hit = cache.get(key);
+    if (hit !== undefined) {
+      return hit;
+    }
+
+    const value = await fn(...args);
+    cache.set(key, value);
+    return value;
+  };
+}
+
+export { TTLCache, memoizeWithTTL };

--- a/lib/data/alphaVantage.js
+++ b/lib/data/alphaVantage.js
@@ -1,0 +1,70 @@
+import { memoizeWithTTL } from "../cache/ttlCache.js";
+
+class AlphaVantageClient {
+  /**
+   * @param {{ apiKey: string; ttlMs?: number; fetcher?: typeof fetch }} options
+   */
+  constructor(options) {
+    if (!options?.apiKey) {
+      throw new Error("Alpha Vantage API key is required");
+    }
+
+    this.options = options;
+    this.fetcher = options.fetcher ?? fetch;
+    const ttlMs = options.ttlMs ?? 15 * 60 * 1000;
+    this.getSeriesCached = memoizeWithTTL(this.fetchDailyAdjusted.bind(this), {
+      ttlMs,
+      getKey: (symbol) => symbol.toUpperCase(),
+    });
+  }
+
+  /**
+   * @param {string} symbol
+   * @param {number} [lookbackDays]
+   */
+  async getAverageVolume(symbol, lookbackDays = 30) {
+    const series = await this.getSeriesCached(symbol);
+    if (!series.length) {
+      return 0;
+    }
+
+    const recent = series.slice(0, lookbackDays);
+    const total = recent.reduce((sum, bar) => sum + bar.volume, 0);
+    return total / recent.length;
+  }
+
+  /**
+   * @param {string} symbol
+   * @returns {Promise<Array<{ date: string; close: number; volume: number }>>}
+   */
+  async fetchDailyAdjusted(symbol) {
+    const params = new URLSearchParams({
+      function: "TIME_SERIES_DAILY_ADJUSTED",
+      symbol,
+      apikey: this.options.apiKey,
+      outputsize: "compact",
+    });
+
+    const response = await this.fetcher(`https://www.alphavantage.co/query?${params.toString()}`);
+    if (!response.ok) {
+      throw new Error(`Alpha Vantage request failed with status ${response.status}`);
+    }
+
+    const payload = await response.json();
+    const timeSeries = payload["Time Series (Daily)"];
+    if (!timeSeries) {
+      return [];
+    }
+
+    return Object.entries(timeSeries)
+      .map(([date, bar]) => ({
+        date,
+        close: Number(bar["4. close"]),
+        volume: Number(bar["6. volume"]),
+      }))
+      .filter((item) => Number.isFinite(item.volume))
+      .sort((a, b) => (a.date < b.date ? 1 : -1));
+  }
+}
+
+export { AlphaVantageClient };

--- a/lib/data/appViews.js
+++ b/lib/data/appViews.js
@@ -1,0 +1,41 @@
+class AppViewsRepository {
+  constructor() {
+    /** @type {Map<string, { symbol: string; views: number; lastViewedAt?: string }>} */
+    this.metrics = new Map();
+  }
+
+  /**
+   * @param {{ symbol: string; views: number; lastViewedAt?: string }} metric
+   */
+  upsert(metric) {
+    const existing = this.metrics.get(metric.symbol);
+    if (!existing) {
+      this.metrics.set(metric.symbol, { ...metric });
+      return;
+    }
+
+    this.metrics.set(metric.symbol, {
+      symbol: metric.symbol,
+      views: metric.views ?? existing.views,
+      lastViewedAt: metric.lastViewedAt ?? existing.lastViewedAt,
+    });
+  }
+
+  /**
+   * @param {number} limit
+   */
+  getMostViewed(limit) {
+    return Array.from(this.metrics.values())
+      .sort((a, b) => b.views - a.views || a.symbol.localeCompare(b.symbol))
+      .slice(0, limit);
+  }
+
+  /**
+   * @param {Array<{ symbol: string; views: number; lastViewedAt?: string }>} metrics
+   */
+  load(metrics) {
+    metrics.forEach((metric) => this.upsert(metric));
+  }
+}
+
+export { AppViewsRepository };

--- a/lib/data/fundamentals.js
+++ b/lib/data/fundamentals.js
@@ -1,0 +1,28 @@
+class InMemoryFundamentalsRepository {
+  /**
+   * @param {Array<{ symbol: string; name?: string; instrumentType: "EQUITY" | "ETF" | "FUND" | "UNKNOWN"; expenseRatio?: number; distributionYield?: number; buyScore?: number; price?: number }>} [initial]
+   */
+  constructor(initial = []) {
+    /** @type {Map<string, any>} */
+    this.records = new Map();
+    initial.forEach((record) => this.records.set(record.symbol, record));
+  }
+
+  /**
+   * @param {string[]} symbols
+   */
+  async find(symbols) {
+    return symbols
+      .map((symbol) => this.records.get(symbol))
+      .filter((record) => Boolean(record));
+  }
+
+  /**
+   * @param {{ symbol: string; name?: string; instrumentType: "EQUITY" | "ETF" | "FUND" | "UNKNOWN"; expenseRatio?: number; distributionYield?: number; buyScore?: number; price?: number }} record
+   */
+  upsert(record) {
+    this.records.set(record.symbol, record);
+  }
+}
+
+export { InMemoryFundamentalsRepository };

--- a/lib/recommendation/ranking.js
+++ b/lib/recommendation/ranking.js
@@ -1,0 +1,117 @@
+function applyRank(symbols, scores, components) {
+  return symbols.map((snapshot, index) => ({
+    ...snapshot,
+    rank: index + 1,
+    metrics: {
+      score: scores.get(snapshot.symbol) ?? 0,
+      components: components.get(snapshot.symbol) ?? {},
+    },
+  }));
+}
+
+function scoreAndSort(snapshots, scoreFor) {
+  const scores = new Map();
+  const components = new Map();
+
+  const sorted = [...snapshots]
+    .map((snapshot) => {
+      const result = scoreFor(snapshot);
+      scores.set(snapshot.symbol, result.score);
+      components.set(snapshot.symbol, result.components);
+      return { snapshot, score: result.score };
+    })
+    .sort((a, b) => b.score - a.score || a.snapshot.symbol.localeCompare(b.snapshot.symbol))
+    .map(({ snapshot }) => snapshot);
+
+  return applyRank(sorted, scores, components);
+}
+
+function normalise(value, maxValue) {
+  if (!maxValue) return 0;
+  return value / maxValue;
+}
+
+function rankPopularSymbols(snapshots, criteria) {
+  const eligible = snapshots.filter(
+    (snapshot) =>
+      (snapshot.averageVolume ?? 0) >= criteria.minimumAverageVolume &&
+      (snapshot.appViews ?? 0) >= criteria.minimumAppViews
+  );
+
+  const maxViews = Math.max(0, ...eligible.map((snapshot) => snapshot.appViews ?? 0));
+  const maxVolume = Math.max(0, ...eligible.map((snapshot) => snapshot.averageVolume ?? 0));
+
+  return scoreAndSort(eligible, (snapshot) => {
+    const views = snapshot.appViews ?? 0;
+    const volume = snapshot.averageVolume ?? 0;
+    const score =
+      normalise(views, maxViews) * criteria.weights.appViews +
+      normalise(volume, maxVolume) * criteria.weights.averageVolume;
+    return {
+      score,
+      components: {
+        appViews: views,
+        averageVolume: volume,
+      },
+    };
+  });
+}
+
+function rankEtfRecommendations(snapshots, criteria) {
+  const eligible = snapshots.filter((snapshot) => {
+    const expenseRatio = snapshot.expenseRatio ?? Number.POSITIVE_INFINITY;
+    const distributionYield = snapshot.distributionYield ?? 0;
+    return expenseRatio <= criteria.maxExpenseRatio && distributionYield >= criteria.minDistributionYield;
+  });
+
+  const maxDistribution = Math.max(0, ...eligible.map((snapshot) => snapshot.distributionYield ?? 0));
+  const maxVolume = Math.max(0, ...eligible.map((snapshot) => snapshot.averageVolume ?? 0));
+
+  return scoreAndSort(eligible, (snapshot) => {
+    const expenseRatio = snapshot.expenseRatio ?? criteria.maxExpenseRatio;
+    const distributionYield = snapshot.distributionYield ?? 0;
+    const averageVolume = snapshot.averageVolume ?? 0;
+
+    const expenseScore = 1 - Math.min(expenseRatio / criteria.maxExpenseRatio, 1);
+    const distributionScore = normalise(distributionYield, maxDistribution);
+    const volumeScore = normalise(averageVolume, maxVolume);
+
+    const score =
+      distributionScore * criteria.weights.distributionYield +
+      expenseScore * criteria.weights.expenseRatio +
+      volumeScore * criteria.weights.averageVolume;
+
+    return {
+      score,
+      components: {
+        distributionYield,
+        expenseRatio,
+        averageVolume,
+      },
+    };
+  });
+}
+
+function rankBuyCandidates(snapshots, criteria) {
+  const eligible = snapshots.filter((snapshot) => (snapshot.buyScore ?? 0) >= criteria.minBuyScore);
+  const maxVolume = Math.max(0, ...eligible.map((snapshot) => snapshot.averageVolume ?? 0));
+  const scoreRange = Math.max(1, 100 - criteria.minBuyScore);
+
+  return scoreAndSort(eligible, (snapshot) => {
+    const buyScore = snapshot.buyScore ?? 0;
+    const averageVolume = snapshot.averageVolume ?? 0;
+    const score =
+      (Math.max(0, buyScore - criteria.minBuyScore) / scoreRange) * criteria.weights.buyScore +
+      Math.sqrt(normalise(averageVolume, maxVolume)) * criteria.weights.averageVolume;
+
+    return {
+      score,
+      components: {
+        buyScore,
+        averageVolume,
+      },
+    };
+  });
+}
+
+export { rankPopularSymbols, rankEtfRecommendations, rankBuyCandidates };

--- a/lib/recommendation/service.js
+++ b/lib/recommendation/service.js
@@ -1,0 +1,120 @@
+import { AlphaVantageClient } from "../data/alphaVantage.js";
+import { AppViewsRepository } from "../data/appViews.js";
+import { InMemoryFundamentalsRepository } from "../data/fundamentals.js";
+import { rankBuyCandidates, rankEtfRecommendations, rankPopularSymbols } from "./ranking.js";
+
+const DEFAULT_POPULAR_CRITERIA = {
+  minimumAverageVolume: 150_000,
+  minimumAppViews: 10,
+  lookbackDays: 30,
+  weights: {
+    appViews: 0.7,
+    averageVolume: 0.3,
+  },
+};
+
+const DEFAULT_ETF_CRITERIA = {
+  maxExpenseRatio: 0.01,
+  minDistributionYield: 0.01,
+  weights: {
+    distributionYield: 0.5,
+    expenseRatio: 0.3,
+    averageVolume: 0.2,
+  },
+};
+
+const DEFAULT_BUY_CRITERIA = {
+  minBuyScore: 70,
+  weights: {
+    buyScore: 0.7,
+    averageVolume: 0.3,
+  },
+};
+
+class RecommendationService {
+  /**
+   * @param {{
+   *  alphaVantageClient: AlphaVantageClient;
+   *  appViewsRepository: AppViewsRepository;
+   *  fundamentalsRepository: InMemoryFundamentalsRepository;
+   *  defaults?: {
+   *    popular?: Partial<typeof DEFAULT_POPULAR_CRITERIA>;
+   *    etf?: Partial<typeof DEFAULT_ETF_CRITERIA>;
+   *    buy?: Partial<typeof DEFAULT_BUY_CRITERIA>;
+   *  };
+   * }} options
+   */
+  constructor(options) {
+    this.options = options;
+    this.popularCriteria = { ...DEFAULT_POPULAR_CRITERIA, ...options.defaults?.popular };
+    this.etfCriteria = { ...DEFAULT_ETF_CRITERIA, ...options.defaults?.etf };
+    this.buyCriteria = { ...DEFAULT_BUY_CRITERIA, ...options.defaults?.buy };
+  }
+
+  async build(limit = 10) {
+    const candidates = await this.collectCandidates(limit);
+
+    const popular = rankPopularSymbols(candidates, this.popularCriteria).slice(0, limit);
+    const etfCandidates = candidates.filter((candidate) => candidate.instrumentType === "ETF");
+    const etf = rankEtfRecommendations(etfCandidates, this.etfCriteria).slice(0, limit);
+    const buy = rankBuyCandidates(candidates, this.buyCriteria).slice(0, limit);
+    const asOf = new Date().toISOString();
+
+    return {
+      popular: {
+        criteria: this.popularCriteria,
+        symbols: popular,
+        asOf,
+      },
+      etf: {
+        criteria: this.etfCriteria,
+        symbols: etf,
+        asOf,
+      },
+      buy: {
+        criteria: this.buyCriteria,
+        symbols: buy,
+        asOf,
+      },
+    };
+  }
+
+  async collectCandidates(limit) {
+    const mostViewed = this.options.appViewsRepository.getMostViewed(limit * 3);
+    const symbols = mostViewed.map((metric) => metric.symbol);
+    const fundamentals = await this.options.fundamentalsRepository.find(symbols);
+
+    const snapshots = await Promise.all(
+      fundamentals.map(async (fundamental) => {
+        const averageVolume = await this.options.alphaVantageClient.getAverageVolume(
+          fundamental.symbol,
+          this.popularCriteria.lookbackDays
+        );
+
+        const appViews = mostViewed.find((metric) => metric.symbol === fundamental.symbol)?.views ?? 0;
+
+        return {
+          symbol: fundamental.symbol,
+          name: fundamental.name,
+          instrumentType: fundamental.instrumentType ?? "UNKNOWN",
+          averageVolume,
+          appViews,
+          expenseRatio: fundamental.expenseRatio,
+          distributionYield: fundamental.distributionYield,
+          buyScore: fundamental.buyScore,
+          price: fundamental.price,
+          lastUpdated: new Date().toISOString(),
+        };
+      })
+    );
+
+    return snapshots;
+  }
+}
+
+export {
+  RecommendationService,
+  DEFAULT_POPULAR_CRITERIA,
+  DEFAULT_ETF_CRITERIA,
+  DEFAULT_BUY_CRITERIA,
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "nisa-support",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/tests/recommendation/ranking.test.js
+++ b/tests/recommendation/ranking.test.js
@@ -1,0 +1,169 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  rankBuyCandidates,
+  rankEtfRecommendations,
+  rankPopularSymbols,
+} from "../../lib/recommendation/ranking.js";
+
+const baseSnapshots = [
+  {
+    symbol: "AAPL",
+    instrumentType: "EQUITY",
+    averageVolume: 1_000_000,
+    appViews: 2000,
+    buyScore: 85,
+  },
+  {
+    symbol: "MSFT",
+    instrumentType: "EQUITY",
+    averageVolume: 900_000,
+    appViews: 1800,
+    buyScore: 80,
+  },
+  {
+    symbol: "VOO",
+    instrumentType: "ETF",
+    averageVolume: 1_200_000,
+    appViews: 1500,
+    expenseRatio: 0.0004,
+    distributionYield: 0.012,
+    buyScore: 78,
+  },
+  {
+    symbol: "QQQ",
+    instrumentType: "ETF",
+    averageVolume: 1_100_000,
+    appViews: 1400,
+    expenseRatio: 0.002,
+    distributionYield: 0.008,
+    buyScore: 72,
+  },
+  {
+    symbol: "SCHD",
+    instrumentType: "ETF",
+    averageVolume: 800_000,
+    appViews: 1300,
+    expenseRatio: 0.0006,
+    distributionYield: 0.031,
+    buyScore: 75,
+  },
+];
+
+test("rankPopularSymbols prioritises views and volume", () => {
+  const criteria = {
+    minimumAverageVolume: 500_000,
+    minimumAppViews: 1000,
+    lookbackDays: 30,
+    weights: {
+      appViews: 0.7,
+      averageVolume: 0.3,
+    },
+  };
+
+  const ranked = rankPopularSymbols(baseSnapshots, criteria);
+  assert.deepEqual(
+    ranked.map((item) => item.symbol),
+    ["AAPL", "MSFT", "VOO", "QQQ", "SCHD"]
+  );
+  assert.deepEqual(ranked[0].metrics.components, { appViews: 2000, averageVolume: 1_000_000 });
+});
+
+test("rankPopularSymbols filters below thresholds", () => {
+  const criteria = {
+    minimumAverageVolume: 500_000,
+    minimumAppViews: 1000,
+    lookbackDays: 30,
+    weights: {
+      appViews: 0.7,
+      averageVolume: 0.3,
+    },
+  };
+
+  const snapshots = [
+    { symbol: "LOWV", instrumentType: "EQUITY", averageVolume: 100, appViews: 5 },
+    { symbol: "MEETS", instrumentType: "EQUITY", averageVolume: 600_000, appViews: 1000 },
+  ];
+  const ranked = rankPopularSymbols(snapshots, criteria);
+  assert.deepEqual(ranked.map((item) => item.symbol), ["MEETS"]);
+});
+
+test("rankEtfRecommendations sorts by yield, expense and liquidity", () => {
+  const criteria = {
+    maxExpenseRatio: 0.01,
+    minDistributionYield: 0.01,
+    weights: {
+      distributionYield: 0.5,
+      expenseRatio: 0.3,
+      averageVolume: 0.2,
+    },
+  };
+
+  const etfs = baseSnapshots.filter((snapshot) => snapshot.instrumentType === "ETF");
+  const ranked = rankEtfRecommendations(etfs, criteria);
+  assert.deepEqual(ranked.map((item) => item.symbol), ["SCHD", "VOO"]);
+  assert.ok(Math.abs(ranked[0].metrics.components.expenseRatio - 0.0006) < 1e-6);
+  assert.ok(Math.abs(ranked[0].metrics.components.distributionYield - 0.031) < 1e-6);
+});
+
+test("rankEtfRecommendations filters ETFs outside constraints", () => {
+  const criteria = {
+    maxExpenseRatio: 0.01,
+    minDistributionYield: 0.01,
+    weights: {
+      distributionYield: 0.5,
+      expenseRatio: 0.3,
+      averageVolume: 0.2,
+    },
+  };
+
+  const snapshots = [
+    {
+      symbol: "HIGHEXP",
+      instrumentType: "ETF",
+      averageVolume: 200_000,
+      expenseRatio: 0.02,
+      distributionYield: 0.02,
+    },
+    {
+      symbol: "LOWYIELD",
+      instrumentType: "ETF",
+      averageVolume: 200_000,
+      expenseRatio: 0.001,
+      distributionYield: 0.005,
+    },
+  ];
+  const ranked = rankEtfRecommendations(snapshots, criteria);
+  assert.equal(ranked.length, 0);
+});
+
+test("rankBuyCandidates orders by buy score and liquidity", () => {
+  const criteria = {
+    minBuyScore: 75,
+    weights: {
+      buyScore: 0.7,
+      averageVolume: 0.3,
+    },
+  };
+
+  const ranked = rankBuyCandidates(baseSnapshots, criteria);
+  assert.deepEqual(ranked.map((item) => item.symbol), ["AAPL", "MSFT", "VOO", "SCHD"]);
+  assert.ok(ranked.every((item) => item.metrics.components.buyScore >= criteria.minBuyScore));
+});
+
+test("rankBuyCandidates filters by minimum score", () => {
+  const criteria = {
+    minBuyScore: 75,
+    weights: {
+      buyScore: 0.7,
+      averageVolume: 0.3,
+    },
+  };
+
+  const snapshots = [
+    { symbol: "LOW", instrumentType: "EQUITY", averageVolume: 200_000, buyScore: 60 },
+    { symbol: "HIGH", instrumentType: "EQUITY", averageVolume: 300_000, buyScore: 90 },
+  ];
+  const ranked = rankBuyCandidates(snapshots, criteria);
+  assert.deepEqual(ranked.map((item) => item.symbol), ["HIGH"]);
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "module": "ESNext",
+    "moduleResolution": "NodeNext",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "resolveJsonModule": true,
+    "types": ["node"],
+    "rootDir": ".",
+    "outDir": "dist"
+  },
+  "include": [
+    "app/**/*",
+    "lib/**/*",
+    "tests/**/*"
+  ]
+}


### PR DESCRIPTION
## Summary
- add a recommendation service that sources symbol snapshots from recent view metrics and Alpha Vantage averages
- compute popular, ETF and buy candidate rankings with explicit scoring criteria and memoised Alpha Vantage access
- expose the new API route and cover the ranking logic with node:test unit tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68cf9a71a410832f87936ab5e0bee236