### PR TITLE
fix: allow openai wrapper to return plain text

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,6 @@
+{
+  "extends": ["next/core-web-vitals"],
+  "rules": {
+    "@next/next/no-img-element": "off"
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+node_modules
+.next
+out
+.DS_Store
+npm-debug.log*
+.env.local
+.env
+coverage

--- a/app/(tabs)/capture/page.tsx
+++ b/app/(tabs)/capture/page.tsx
@@ -1,0 +1,249 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { DecisionBadge } from '@/components/DecisionBadge';
+import { ScoreBar } from '@/components/ScoreBar';
+import { MetricChip } from '@/components/MetricChip';
+import { Card } from '@/components/Card';
+import { ChartCanvas } from '@/components/ChartCanvas';
+import { useAppSettings } from '@/lib/useAppSettings';
+import { DISCLAIMER } from '@/lib/constants';
+import type { AdvicePayload, PhotoAnalysis, ScoreResult } from '@/lib/types';
+import ja from '@/public/i18n/ja.json';
+
+const t = ja.capture;
+
+interface ChartPoint {
+  timestamp: number;
+  close: number;
+}
+
+export default function CapturePage() {
+  const { settings, ready } = useAppSettings();
+  const [preview, setPreview] = useState<string | null>(null);
+  const [analysis, setAnalysis] = useState<PhotoAnalysis | null>(null);
+  const [score, setScore] = useState<ScoreResult | null>(null);
+  const [advice, setAdvice] = useState<AdvicePayload | null>(null);
+  const [chart, setChart] = useState<ChartPoint[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [symbol, setSymbol] = useState<string | null>(null);
+
+  const handleFile = async (file: File) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      if (typeof reader.result === 'string') {
+        setPreview(reader.result);
+      }
+    };
+    reader.readAsDataURL(file);
+  };
+
+  const handleAnalyze = async () => {
+    if (!preview || !ready) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const analyzeRes = await fetch('/api/analyze-photo', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          image: preview,
+          hints: analysis ? { timeframe: analysis.timeframe } : {},
+          openAIApiKey: settings.openAIApiKey,
+          alphaApiKey: settings.alphaVantageApiKey
+        })
+      });
+      if (!analyzeRes.ok) throw new Error(await analyzeRes.text());
+      const analyzeJson = await analyzeRes.json();
+      const resolvedSymbol = analyzeJson.resolvedSymbol as string | null;
+      setAnalysis(analyzeJson.photo as PhotoAnalysis);
+      setSymbol(resolvedSymbol);
+      if (!resolvedSymbol) {
+        throw new Error('銘柄を特定できませんでした');
+      }
+
+      const alphaKey = settings.alphaVantageApiKey ? `&apiKey=${encodeURIComponent(settings.alphaVantageApiKey)}` : '';
+      const [dailyRes, monthlyRes, overviewRes, etfRes] = await Promise.all([
+        fetch(`/api/alpha?type=daily&symbol=${resolvedSymbol}${alphaKey}`),
+        fetch(`/api/alpha?type=monthly&symbol=${resolvedSymbol}${alphaKey}`),
+        fetch(`/api/alpha?type=overview&symbol=${resolvedSymbol}${alphaKey}`),
+        fetch(`/api/alpha?type=etf&symbol=${resolvedSymbol}${alphaKey}`)
+      ]);
+
+      if (!dailyRes.ok) throw new Error(await dailyRes.text());
+      if (!monthlyRes.ok) throw new Error(await monthlyRes.text());
+
+      const daily = await dailyRes.json();
+      const monthly = await monthlyRes.json();
+      const overview = overviewRes.ok ? await overviewRes.json() : null;
+      const profile = etfRes.ok ? await etfRes.json() : null;
+
+      const chartSeries: ChartPoint[] = (daily as any[]).slice(-120).map((point) => ({
+        timestamp: new Date(point.date).getTime(),
+        close: point.adjustedClose
+      }));
+      setChart(chartSeries);
+
+      const scoreRes = await fetch('/api/score', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          dailies: daily,
+          monthlies: monthly,
+          profile,
+          overview,
+          mode: settings.mode
+        })
+      });
+      if (!scoreRes.ok) throw new Error(await scoreRes.text());
+      const scoreJson = (await scoreRes.json()) as ScoreResult;
+      setScore(scoreJson);
+
+      const adviceRes = await fetch('/api/advice', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          decision: scoreJson.decision,
+          reasons: scoreJson.reasons.map((r) => r.label),
+          counters: scoreJson.counters.map((r) => r.label),
+          nextSteps: ['関連指数と比較する', '想定リスクと期間を再確認する'],
+          openAIApiKey: settings.openAIApiKey
+        })
+      });
+      if (adviceRes.ok) {
+        setAdvice((await adviceRes.json()) as AdvicePayload);
+      } else {
+        setAdvice(null);
+      }
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const metrics = useMemo(() => {
+    if (!score?.metrics) return [];
+    return [
+      score.metrics.sma20 && { label: 'SMA20', value: score.metrics.sma20.toFixed(2) },
+      score.metrics.sma50 && { label: 'SMA50', value: score.metrics.sma50.toFixed(2) },
+      score.metrics.sma200 && { label: 'SMA200', value: score.metrics.sma200.toFixed(2) },
+      score.metrics.rsi14 && { label: 'RSI14', value: score.metrics.rsi14.toFixed(1) },
+      score.metrics.dividendYieldTrailing && {
+        label: '配当利回り',
+        value: `${score.metrics.dividendYieldTrailing.toFixed(2)}%`
+      }
+    ].filter(Boolean) as { label: string; value: string }[];
+  }, [score]);
+
+  return (
+    <div className="mx-auto flex max-w-3xl flex-col gap-4">
+      <header className="space-y-1">
+        <h2 className="text-xl font-semibold">{t.title}</h2>
+        <p className="text-xs text-white/60">{DISCLAIMER}</p>
+      </header>
+      <div className="flex flex-col gap-4">
+        <label className="flex cursor-pointer flex-col items-center justify-center rounded-2xl border-2 border-dashed border-white/20 bg-white/5 p-6 text-sm text-white/80 focus-within:ring-2 focus-within:ring-kachi-accent">
+          <span>{t.upload}</span>
+          <input
+            type="file"
+            accept="image/*"
+            className="sr-only"
+            onChange={async (event) => {
+              const file = event.target.files?.[0];
+              if (file) {
+                await handleFile(file);
+              }
+            }}
+          />
+        </label>
+        {preview && (
+          <img src={preview} alt="チャートプレビュー" className="w-full rounded-2xl border border-white/10" />
+        )}
+        <button
+          type="button"
+          onClick={handleAnalyze}
+          disabled={!preview || loading || !ready}
+          className="rounded-full bg-kachi-accent px-4 py-2 text-sm font-semibold text-kachi-shade disabled:opacity-50"
+        >
+          {loading ? t.analyzing : t.recalculate}
+        </button>
+        {error && <p className="text-xs text-signal-sell">{error}</p>}
+      </div>
+
+      {score && (
+        <Card className="space-y-4">
+          <div className="flex items-center justify-between">
+            <div>
+              <p className="text-sm font-semibold">{symbol}</p>
+              <p className="text-xs text-white/60">モード: {score.horizon === 'long' ? '長期' : 'スイング'}</p>
+            </div>
+            <DecisionBadge decision={score.decision} />
+          </div>
+          <ScoreBar value={score.confidence} />
+          <div className="flex flex-wrap gap-2">
+            {metrics.map((metric) => (
+              <MetricChip key={metric.label} label={metric.label} value={metric.value} />
+            ))}
+          </div>
+          <div className="grid gap-2 text-xs">
+            <div>
+              <h3 className="text-white/70">根拠</h3>
+              <ul className="mt-1 space-y-1">
+                {score.reasons.map((reason) => (
+                  <li key={reason.label}>• {reason.label}</li>
+                ))}
+              </ul>
+            </div>
+            <div>
+              <h3 className="text-white/70">反対要因</h3>
+              <ul className="mt-1 space-y-1">
+                {score.counters.map((reason) => (
+                  <li key={reason.label}>• {reason.label}</li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        </Card>
+      )}
+
+      {chart.length > 0 && (
+        <Card>
+          <ChartCanvas series={chart} />
+        </Card>
+      )}
+
+      {advice && (
+        <Card className="space-y-2 text-sm">
+          <h3 className="text-base font-semibold text-kachi-accent">{advice.headline}</h3>
+          <div>
+            <h4 className="text-xs text-white/60">ポイント</h4>
+            <ul className="mt-1 space-y-1">
+              {advice.rationale.map((item) => (
+                <li key={item}>• {item}</li>
+              ))}
+            </ul>
+          </div>
+          <div>
+            <h4 className="text-xs text-white/60">留意点</h4>
+            <ul className="mt-1 space-y-1">
+              {advice.counterpoints.map((item) => (
+                <li key={item}>• {item}</li>
+              ))}
+            </ul>
+          </div>
+          <div>
+            <h4 className="text-xs text-white/60">次のアクション</h4>
+            <ul className="mt-1 space-y-1">
+              {advice.next_steps.map((item) => (
+                <li key={item}>• {item}</li>
+              ))}
+            </ul>
+          </div>
+          <p className="text-[10px] text-white/50">{advice.disclaimer}</p>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/app/(tabs)/chat/page.tsx
+++ b/app/(tabs)/chat/page.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import { FormEvent, useState } from 'react';
+import { ChatBubble } from '@/components/ChatBubble';
+import { Card } from '@/components/Card';
+import { useAppSettings } from '@/lib/useAppSettings';
+import { DISCLAIMER } from '@/lib/constants';
+import ja from '@/public/i18n/ja.json';
+
+const t = ja.chat;
+
+interface Message {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+export default function ChatPage() {
+  const { settings, ready } = useAppSettings();
+  const [messages, setMessages] = useState<Message[]>([
+    {
+      role: 'assistant',
+      content: '解析結果や気になる銘柄について質問してください。投資助言ではなく教育的な視点でお答えします。'
+    }
+  ]);
+  const [input, setInput] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!input.trim() || !ready) return;
+    const newMessage: Message = { role: 'user', content: input.trim() };
+    const nextMessages = [...messages, newMessage];
+    setMessages(nextMessages);
+    setInput('');
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await fetch('/api/chat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          messages: nextMessages,
+          openAIApiKey: settings.openAIApiKey
+        })
+      });
+      if (!response.ok) throw new Error(await response.text());
+      const data = await response.json();
+      setMessages((prev) => [...prev, { role: 'assistant', content: data.text }]);
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="mx-auto flex max-w-3xl flex-1 flex-col gap-4">
+      <header>
+        <h2 className="text-xl font-semibold">{t.title}</h2>
+        <p className="text-xs text-white/60">{DISCLAIMER}</p>
+      </header>
+      <Card className="flex max-h-[60vh] flex-1 flex-col gap-3 overflow-y-auto">
+        {messages.map((message, index) => (
+          <ChatBubble key={index} role={message.role}>
+            {message.content}
+          </ChatBubble>
+        ))}
+      </Card>
+      <form onSubmit={handleSubmit} className="flex flex-col gap-2">
+        <textarea
+          value={input}
+          onChange={(event) => setInput(event.target.value)}
+          placeholder={t.placeholder}
+          className="h-24 w-full rounded-2xl border border-white/10 bg-white/10 p-4 text-sm text-white focus:border-kachi-accent focus:outline-none focus:ring-2 focus:ring-kachi-accent"
+        />
+        <button
+          type="submit"
+          disabled={loading || !input.trim()}
+          className="rounded-full bg-kachi-accent px-4 py-2 text-sm font-semibold text-kachi-shade disabled:opacity-50"
+        >
+          送信
+        </button>
+        {error && <p className="text-xs text-signal-sell">{error}</p>}
+      </form>
+    </div>
+  );
+}

--- a/app/(tabs)/nav/page.tsx
+++ b/app/(tabs)/nav/page.tsx
@@ -1,0 +1,123 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { StockCard } from '@/components/StockCard';
+import { Card } from '@/components/Card';
+import { useAppSettings } from '@/lib/useAppSettings';
+import { DecisionBadge } from '@/components/DecisionBadge';
+import { ScoreBar } from '@/components/ScoreBar';
+import ja from '@/public/i18n/ja.json';
+
+const t = ja.nav;
+
+interface RecommendationItem {
+  symbol: string;
+  name: string;
+  decision: 'BUY' | 'SELL' | 'NEUTRAL' | 'ABSTAIN';
+  confidence: number;
+  expenseRatio?: number | null;
+  dividendYield?: number | null;
+}
+
+export default function NavPage() {
+  const { settings, ready } = useAppSettings();
+  const [data, setData] = useState<{ popular: RecommendationItem[]; etfs: RecommendationItem[]; buyCandidates: RecommendationItem[] } | null>(null);
+  const [active, setActive] = useState<RecommendationItem | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!ready || !settings.alphaVantageApiKey) return;
+    const controller = new AbortController();
+    const fetchData = async () => {
+      try {
+        const res = await fetch(`/api/recommend?apiKey=${encodeURIComponent(settings.alphaVantageApiKey)}&mode=${settings.mode}`, {
+          signal: controller.signal
+        });
+        if (!res.ok) throw new Error(await res.text());
+        const json = await res.json();
+        setData(json);
+        setActive(json.buyCandidates?.[0] ?? json.popular?.[0] ?? null);
+      } catch (err) {
+        if (!(err instanceof DOMException)) {
+          setError((err as Error).message);
+        }
+      }
+    };
+    fetchData();
+    return () => controller.abort();
+  }, [ready, settings.alphaVantageApiKey, settings.mode]);
+
+  return (
+    <div className="mx-auto flex max-w-3xl flex-col gap-4">
+      <header>
+        <h2 className="text-xl font-semibold">{t.title}</h2>
+        <p className="text-xs text-white/60">人気銘柄や低コストETFを自動で集計します。</p>
+      </header>
+      {error && <p className="text-xs text-signal-sell">{error}</p>}
+      <section className="space-y-3">
+        <h3 className="text-sm font-semibold text-kachi-accent">{t.popular}</h3>
+        <div className="grid gap-3">
+          {data?.popular?.map((item) => (
+            <StockCard
+              key={`popular-${item.symbol}`}
+              symbol={item.symbol}
+              name={item.name}
+              decision={item.decision}
+              score={item.confidence}
+              expenseRatio={item.expenseRatio ?? undefined}
+              dividendYield={item.dividendYield ?? undefined}
+              onSelect={() => setActive(item)}
+            />
+          ))}
+        </div>
+      </section>
+      <section className="space-y-3">
+        <h3 className="text-sm font-semibold text-kachi-accent">{t.etf}</h3>
+        <div className="grid gap-3">
+          {data?.etfs?.map((item) => (
+            <StockCard
+              key={`etf-${item.symbol}`}
+              symbol={item.symbol}
+              name={item.name}
+              decision={item.decision}
+              score={item.confidence}
+              expenseRatio={item.expenseRatio ?? undefined}
+              dividendYield={item.dividendYield ?? undefined}
+              onSelect={() => setActive(item)}
+            />
+          ))}
+        </div>
+      </section>
+      <section className="space-y-3">
+        <h3 className="text-sm font-semibold text-kachi-accent">{t.buy}</h3>
+        <div className="grid gap-3">
+          {data?.buyCandidates?.map((item) => (
+            <StockCard
+              key={`buy-${item.symbol}`}
+              symbol={item.symbol}
+              name={item.name}
+              decision={item.decision}
+              score={item.confidence}
+              expenseRatio={item.expenseRatio ?? undefined}
+              dividendYield={item.dividendYield ?? undefined}
+              onSelect={() => setActive(item)}
+            />
+          ))}
+        </div>
+      </section>
+      {active && (
+        <Card className="space-y-2 text-sm">
+          <div className="flex items-center justify-between">
+            <div>
+              <p className="text-base font-semibold">{active.symbol}</p>
+              <p className="text-xs text-white/60">{active.name}</p>
+            </div>
+            <DecisionBadge decision={active.decision} />
+          </div>
+          <ScoreBar value={active.confidence} />
+          <p className="text-xs text-white/70">勝色スコアは機械的に算出された教育用シグナルです。</p>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/app/(tabs)/nisa/page.tsx
+++ b/app/(tabs)/nisa/page.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { Card } from '@/components/Card';
+import ja from '@/public/i18n/ja.json';
+
+const t = ja.nisa;
+
+export default function NisaPage() {
+  const [monthly, setMonthly] = useState(5_0000);
+  const [years, setYears] = useState(10);
+  const [returnRate, setReturnRate] = useState(0.04);
+
+  const futureValue = useMemo(() => {
+    const periods = years * 12;
+    const monthlyRate = returnRate / 12;
+    let total = 0;
+    for (let i = 0; i < periods; i += 1) {
+      total = (total + monthly) * (1 + monthlyRate);
+    }
+    return Math.round(total);
+  }, [monthly, years, returnRate]);
+
+  return (
+    <div className="mx-auto flex max-w-3xl flex-col gap-4">
+      <header>
+        <h2 className="text-xl font-semibold">{t.title}</h2>
+        <p className="text-xs text-white/60">非課税枠を活用して長期分散投資を学びましょう。</p>
+      </header>
+      <Card className="space-y-3 text-sm">
+        <h3 className="text-base font-semibold text-kachi-accent">{t.overview}</h3>
+        <ul className="list-disc space-y-1 pl-5 text-white/80">
+          <li>年間360万円（つみたて枠120万円 + 成長投資枠240万円）が上限。</li>
+          <li>非課税保有期間は無期限。売却枠は翌年に再利用可能。</li>
+          <li>低コストETFや投信での分散投資が王道。過度な集中は避けましょう。</li>
+        </ul>
+      </Card>
+      <Card className="space-y-3 text-sm">
+        <h3 className="text-base font-semibold text-kachi-accent">{t.qa}</h3>
+        <details className="rounded-xl bg-white/5 p-3">
+          <summary className="cursor-pointer font-semibold">途中で売却しても良い？</summary>
+          <p className="mt-2 text-white/70">非課税枠は売却時に消化されますが、翌年に限り同額を再利用できます。長期計画に基づき、必要資金は生活防衛資金で確保しましょう。</p>
+        </details>
+        <details className="rounded-xl bg-white/5 p-3">
+          <summary className="cursor-pointer font-semibold">銘柄はどう選ぶ？</summary>
+          <p className="mt-2 text-white/70">費用率が低く、分散が効いたETFやインデックスファンドが基本。アプリの銘柄ナビから手数料・配当・リスクを比較できます。</p>
+        </details>
+      </Card>
+      <Card className="space-y-3 text-sm">
+        <h3 className="text-base font-semibold text-kachi-accent">{t.steps}</h3>
+        <ol className="list-decimal space-y-1 pl-5 text-white/80">
+          <li>目標期間とリスク許容度を定義。</li>
+          <li>APIキーを登録し、チャート解析でシグナルの見方を学ぶ。</li>
+          <li>銘柄ナビで低コストETFを比較し、分散ポートフォリオを組む。</li>
+          <li>定期的に振り返り、必要に応じてリバランス。</li>
+        </ol>
+      </Card>
+      <Card className="space-y-3 text-sm">
+        <h3 className="text-base font-semibold text-kachi-accent">{t.simulator}</h3>
+        <div className="grid gap-2 sm:grid-cols-3">
+          <label className="flex flex-col gap-1">
+            <span className="text-xs text-white/60">毎月の積立額（円）</span>
+            <input
+              type="number"
+              value={monthly}
+              onChange={(event) => setMonthly(Number(event.target.value))}
+              className="rounded-xl border border-white/10 bg-white/10 p-2 text-sm text-white focus:border-kachi-accent focus:outline-none focus:ring-2 focus:ring-kachi-accent"
+            />
+          </label>
+          <label className="flex flex-col gap-1">
+            <span className="text-xs text-white/60">運用年数</span>
+            <input
+              type="number"
+              value={years}
+              onChange={(event) => setYears(Number(event.target.value))}
+              className="rounded-xl border border-white/10 bg-white/10 p-2 text-sm text-white focus:border-kachi-accent focus:outline-none focus:ring-2 focus:ring-kachi-accent"
+            />
+          </label>
+          <label className="flex flex-col gap-1">
+            <span className="text-xs text-white/60">想定年率リターン</span>
+            <input
+              type="number"
+              step="0.01"
+              value={returnRate}
+              onChange={(event) => setReturnRate(Number(event.target.value))}
+              className="rounded-xl border border-white/10 bg-white/10 p-2 text-sm text-white focus:border-kachi-accent focus:outline-none focus:ring-2 focus:ring-kachi-accent"
+            />
+          </label>
+        </div>
+        <p className="text-xs text-white/70">将来価値（概算）: <span className="text-kachi-accent text-lg font-semibold">{futureValue.toLocaleString()}円</span></p>
+        <p className="text-[10px] text-white/50">シミュレーションは税金・手数料を考慮しておらず、実績を保証するものではありません。</p>
+      </Card>
+    </div>
+  );
+}

--- a/app/(tabs)/settings/page.tsx
+++ b/app/(tabs)/settings/page.tsx
@@ -1,0 +1,121 @@
+'use client';
+
+import { FormEvent, useEffect, useState } from 'react';
+import { Card } from '@/components/Card';
+import { useAppSettings } from '@/lib/useAppSettings';
+import { DEFAULT_THRESHOLDS, DISCLAIMER } from '@/lib/constants';
+import type { AppSettings } from '@/lib/types';
+import ja from '@/public/i18n/ja.json';
+
+const t = ja.settings;
+
+export default function SettingsPage() {
+  const { settings, setSettings, ready } = useAppSettings();
+  const [local, setLocal] = useState<AppSettings>({
+    thresholds: DEFAULT_THRESHOLDS,
+    mode: 'long',
+    theme: 'system',
+    acceptedDisclaimer: false
+  });
+  const [status, setStatus] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (ready) {
+      setLocal(settings);
+    }
+  }, [ready, settings]);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    await setSettings(local);
+    setStatus('保存しました');
+    setTimeout(() => setStatus(null), 3000);
+  };
+
+  return (
+    <div className="mx-auto flex max-w-3xl flex-col gap-4">
+      <header>
+        <h2 className="text-xl font-semibold">{t.title}</h2>
+        <p className="text-xs text-white/60">{DISCLAIMER}</p>
+      </header>
+      <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+        <Card className="space-y-3 text-sm">
+          <h3 className="text-base font-semibold text-kachi-accent">APIキー</h3>
+          <label className="flex flex-col gap-1">
+            <span className="text-xs text-white/60">{t.openai}</span>
+            <input
+              type="password"
+              value={local.openAIApiKey ?? ''}
+              onChange={(event) => setLocal((prev) => ({ ...prev, openAIApiKey: event.target.value }))}
+              className="rounded-xl border border-white/10 bg-white/10 p-2 text-sm text-white focus:border-kachi-accent focus:outline-none focus:ring-2 focus:ring-kachi-accent"
+            />
+          </label>
+          <label className="flex flex-col gap-1">
+            <span className="text-xs text-white/60">{t.alpha}</span>
+            <input
+              type="password"
+              value={local.alphaVantageApiKey ?? ''}
+              onChange={(event) => setLocal((prev) => ({ ...prev, alphaVantageApiKey: event.target.value }))}
+              className="rounded-xl border border-white/10 bg-white/10 p-2 text-sm text-white focus:border-kachi-accent focus:outline-none focus:ring-2 focus:ring-kachi-accent"
+            />
+          </label>
+        </Card>
+        <Card className="space-y-3 text-sm">
+          <h3 className="text-base font-semibold text-kachi-accent">{t.mode}</h3>
+          <div className="flex gap-3">
+            <label className="flex items-center gap-2 text-xs">
+              <input
+                type="radio"
+                name="mode"
+                value="long"
+                checked={local.mode === 'long'}
+                onChange={() => setLocal((prev) => ({ ...prev, mode: 'long' }))}
+              />
+              {t.long}
+            </label>
+            <label className="flex items-center gap-2 text-xs">
+              <input
+                type="radio"
+                name="mode"
+                value="swing"
+                checked={local.mode === 'swing'}
+                onChange={() => setLocal((prev) => ({ ...prev, mode: 'swing' }))}
+              />
+              {t.swing}
+            </label>
+          </div>
+        </Card>
+        <Card className="space-y-3 text-sm">
+          <h3 className="text-base font-semibold text-kachi-accent">{t.theme}</h3>
+          <select
+            value={local.theme}
+            onChange={(event) => setLocal((prev) => ({ ...prev, theme: event.target.value as AppSettings['theme'] }))}
+            className="rounded-xl border border-white/10 bg-white/10 p-2 text-sm text-white focus:border-kachi-accent focus:outline-none focus:ring-2 focus:ring-kachi-accent"
+          >
+            <option value="system">システム</option>
+            <option value="light">ライト</option>
+            <option value="dark">ダーク</option>
+          </select>
+        </Card>
+        <Card className="space-y-3 text-sm">
+          <label className="flex items-center gap-2 text-xs">
+            <input
+              type="checkbox"
+              checked={local.acceptedDisclaimer}
+              onChange={(event) => setLocal((prev) => ({ ...prev, acceptedDisclaimer: event.target.checked }))}
+            />
+            {t.disclaimer}
+          </label>
+        </Card>
+        <button
+          type="submit"
+          className="rounded-full bg-kachi-accent px-4 py-2 text-sm font-semibold text-kachi-shade disabled:opacity-50"
+          disabled={!local.acceptedDisclaimer}
+        >
+          {t.save}
+        </button>
+        {status && <p className="text-xs text-kachi-accent">{status}</p>}
+      </form>
+    </div>
+  );
+}

--- a/app/api/advice/route.ts
+++ b/app/api/advice/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from 'next/server';
+import { formatAdvice } from '@/lib/openai';
+
+export const runtime = 'edge';
+
+export async function POST(request: Request) {
+  try {
+    const { decision, reasons, counters, nextSteps, openAIApiKey } = await request.json();
+    if (!decision || !Array.isArray(reasons) || !Array.isArray(counters)) {
+      return NextResponse.json({ error: 'invalid payload' }, { status: 400 });
+    }
+    const payload = await formatAdvice({ decision, reasons, counters, nextSteps, apiKey: openAIApiKey });
+    return NextResponse.json(payload);
+  } catch (error) {
+    console.error('Advice route error', error);
+    return NextResponse.json({ error: (error as Error).message }, { status: 500 });
+  }
+}

--- a/app/api/alpha/route.ts
+++ b/app/api/alpha/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { fetchDailyAdjusted, fetchMonthlyAdjusted, fetchOverview, fetchEtfProfile, fetchListings } from '@/lib/alphavantage';
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const type = searchParams.get('type');
+  const symbol = searchParams.get('symbol') ?? undefined;
+  const apiKey = searchParams.get('apiKey') ?? undefined;
+
+  try {
+    switch (type) {
+      case 'daily':
+        if (!symbol) throw new Error('symbol is required');
+        return NextResponse.json(await fetchDailyAdjusted(symbol, apiKey));
+      case 'monthly':
+        if (!symbol) throw new Error('symbol is required');
+        return NextResponse.json(await fetchMonthlyAdjusted(symbol, apiKey));
+      case 'overview':
+        if (!symbol) throw new Error('symbol is required');
+        return NextResponse.json(await fetchOverview(symbol, apiKey));
+      case 'etf':
+        if (!symbol) throw new Error('symbol is required');
+        return NextResponse.json(await fetchEtfProfile(symbol, apiKey));
+      case 'listings':
+        return NextResponse.json(await fetchListings(apiKey));
+      default:
+        return NextResponse.json({ error: 'unknown type' }, { status: 400 });
+    }
+  } catch (error) {
+    console.error('Alpha route error', error);
+    return NextResponse.json({ error: (error as Error).message }, { status: 500 });
+  }
+}

--- a/app/api/analyze-photo/route.ts
+++ b/app/api/analyze-photo/route.ts
@@ -1,0 +1,42 @@
+import { NextResponse } from 'next/server';
+import { analyzePhoto } from '@/lib/openai';
+import { fetchSymbolSearch, fetchListings } from '@/lib/alphavantage';
+import { reconcileSymbol } from '@/lib/reconcile';
+import type { PhotoAnalysis } from '@/lib/types';
+
+export const runtime = 'edge';
+
+export async function POST(request: Request) {
+  try {
+    const { image, hints, openAIApiKey, alphaApiKey } = await request.json();
+    if (!image) {
+      return NextResponse.json({ error: 'image is required' }, { status: 400 });
+    }
+
+    const photoJson: PhotoAnalysis = await analyzePhoto({ image, hints, apiKey: openAIApiKey });
+    let resolved: string | null = null;
+    let universe: string[] = [];
+
+    if (alphaApiKey) {
+      universe = await fetchListings(alphaApiKey);
+    }
+
+    if (hints?.symbolText) {
+      try {
+        const matches = await fetchSymbolSearch(hints.symbolText, alphaApiKey);
+        resolved = matches[0]?.symbol ?? null;
+      } catch (error) {
+        console.error('Symbol search failed', error);
+      }
+    }
+
+    if (!resolved) {
+      resolved = reconcileSymbol(photoJson, hints?.symbolText ?? null, universe);
+    }
+
+    return NextResponse.json({ photo: photoJson, resolvedSymbol: resolved });
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json({ error: (error as Error).message }, { status: 500 });
+  }
+}

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from 'next/server';
+import { chatEducator } from '@/lib/openai';
+
+export const runtime = 'edge';
+
+export async function POST(request: Request) {
+  try {
+    const { messages, openAIApiKey } = await request.json();
+    if (!Array.isArray(messages) || messages.length === 0) {
+      return NextResponse.json({ error: 'messages are required' }, { status: 400 });
+    }
+    const text = await chatEducator({ messages, apiKey: openAIApiKey });
+    return NextResponse.json({ text });
+  } catch (error) {
+    console.error('Chat route error', error);
+    return NextResponse.json({ error: (error as Error).message }, { status: 500 });
+  }
+}

--- a/app/api/recommend/route.ts
+++ b/app/api/recommend/route.ts
@@ -1,0 +1,72 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { fetchDailyAdjusted, fetchMonthlyAdjusted, fetchOverview, fetchEtfProfile, fetchListings } from '@/lib/alphavantage';
+import { buildIndicatorSet } from '@/lib/indicators';
+import { decide } from '@/lib/scoring';
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const apiKey = searchParams.get('apiKey') ?? undefined;
+  const symbolsQuery = searchParams.get('symbols');
+  const limit = Number(searchParams.get('limit') ?? '5');
+  const mode = (searchParams.get('mode') as 'long' | 'swing') ?? 'long';
+
+  if (!apiKey) {
+    return NextResponse.json({ error: 'apiKey is required' }, { status: 400 });
+  }
+
+  try {
+    let symbols: string[] = [];
+    if (symbolsQuery) {
+      symbols = symbolsQuery.split(',').map((sym) => sym.trim().toUpperCase());
+    } else {
+      const listings = await fetchListings(apiKey);
+      symbols = listings.slice(0, limit);
+    }
+
+    const popular: any[] = [];
+    const etfs: any[] = [];
+    const buyCandidates: any[] = [];
+
+    for (const symbol of symbols) {
+      try {
+        const [dailies, monthlies, overview, profile] = await Promise.all([
+          fetchDailyAdjusted(symbol, apiKey),
+          fetchMonthlyAdjusted(symbol, apiKey),
+          fetchOverview(symbol, apiKey),
+          fetchEtfProfile(symbol, apiKey)
+        ]);
+        if (!dailies.length || !monthlies.length) continue;
+        const indicators = buildIndicatorSet(dailies, monthlies);
+        const result = decide({ metrics: indicators, dailies, monthlies, mode, overview, profile });
+        const avgVolume = dailies.slice(-20).reduce((sum, item) => sum + item.volume, 0) / Math.min(20, dailies.length);
+        const base = {
+          symbol,
+          name: overview?.name ?? profile?.name ?? symbol,
+          decision: result.decision,
+          confidence: result.confidence,
+          expenseRatio: profile?.expenseRatio ?? null,
+          dividendYield: indicators.dividendYieldTrailing ?? overview?.dividendYield ?? null,
+          averageVolume: avgVolume
+        };
+        popular.push(base);
+        if (profile?.expenseRatio !== undefined) {
+          etfs.push(base);
+        }
+        if (result.decision === 'BUY') {
+          buyCandidates.push(base);
+        }
+      } catch (error) {
+        console.error('Recommend error', symbol, error);
+      }
+    }
+
+    popular.sort((a, b) => (b.averageVolume ?? 0) - (a.averageVolume ?? 0));
+    etfs.sort((a, b) => (a.expenseRatio ?? 999) - (b.expenseRatio ?? 999));
+    buyCandidates.sort((a, b) => (b.confidence ?? 0) - (a.confidence ?? 0));
+
+    return NextResponse.json({ popular, etfs, buyCandidates });
+  } catch (error) {
+    console.error('Recommend route error', error);
+    return NextResponse.json({ error: (error as Error).message }, { status: 500 });
+  }
+}

--- a/app/api/score/route.ts
+++ b/app/api/score/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from 'next/server';
+import { buildIndicatorSet } from '@/lib/indicators';
+import { decide } from '@/lib/scoring';
+import { detectAnomalies } from '@/lib/reconcile';
+import type { AlphaDailyPoint, AlphaMonthlyPoint, EtfProfile, OverviewProfile } from '@/lib/types';
+
+export async function POST(request: Request) {
+  try {
+    const { dailies, monthlies, profile, overview, mode } = await request.json();
+    if (!Array.isArray(dailies) || !Array.isArray(monthlies)) {
+      return NextResponse.json({ error: 'series are required' }, { status: 400 });
+    }
+    const indicators = buildIndicatorSet(dailies as AlphaDailyPoint[], monthlies as AlphaMonthlyPoint[]);
+    const anomalies = detectAnomalies(dailies as AlphaDailyPoint[]);
+    const result = decide({
+      metrics: indicators,
+      dailies,
+      monthlies,
+      mode: mode === 'swing' ? 'swing' : 'long',
+      profile: (profile ?? null) as EtfProfile | null,
+      overview: (overview ?? null) as OverviewProfile | null,
+      anomalies
+    });
+    return NextResponse.json(result);
+  } catch (error) {
+    console.error('Score route error', error);
+    return NextResponse.json({ error: (error as Error).message }, { status: 500 });
+  }
+}

--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -1,0 +1,18 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { fetchSymbolSearch } from '@/lib/alphavantage';
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const q = searchParams.get('q');
+  const apiKey = searchParams.get('apiKey') ?? undefined;
+  if (!q) {
+    return NextResponse.json({ error: 'q is required' }, { status: 400 });
+  }
+  try {
+    const matches = await fetchSymbolSearch(q, apiKey);
+    return NextResponse.json(matches);
+  } catch (error) {
+    console.error('Search route error', error);
+    return NextResponse.json({ error: (error as Error).message }, { status: 500 });
+  }
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,19 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: dark light;
+}
+
+body {
+  @apply bg-kachi text-kachi-textdark min-h-screen;
+}
+
+a {
+  @apply text-kachi-accent hover:text-kachi-accent2;
+}
+
+main {
+  @apply min-h-screen bg-kachi;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,36 @@
+import './globals.css';
+import type { Metadata } from 'next';
+import { clsx } from 'clsx';
+import { K2D } from 'next/font/google';
+import { Layout } from '@/components/Layout';
+
+const k2d = K2D({
+  subsets: ['latin'],
+  weight: ['400', '600', '700'],
+  variable: '--font-k2d'
+});
+
+export const metadata: Metadata = {
+  title: 'NISAサポート',
+  description: '勝色テーマのNISA教育支援PWA',
+  themeColor: '#0F2540',
+  manifest: '/manifest.webmanifest',
+  icons: {
+    icon: '/icons/icon-192.svg',
+    apple: '/icons/icon-512.svg'
+  }
+};
+
+export default function RootLayout({
+  children
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="ja" className={clsx('bg-kachi text-kachi-textdark', k2d.variable)}>
+      <body className="min-h-screen bg-kachi text-kachi-textdark">
+        <Layout>{children}</Layout>
+      </body>
+    </html>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation';
+
+export default function IndexPage() {
+  redirect('/capture');
+}

--- a/components/Card.tsx
+++ b/components/Card.tsx
@@ -1,0 +1,13 @@
+import { clsx } from 'clsx';
+
+export function Card({
+  children,
+  className
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <div className={clsx('rounded-2xl bg-kachi-surface/90 p-4 shadow-kachi backdrop-blur', className)}>{children}</div>
+  );
+}

--- a/components/ChartCanvas.tsx
+++ b/components/ChartCanvas.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+interface Point {
+  timestamp: number;
+  close: number;
+}
+
+export function ChartCanvas({ series }: { series: Point[] }) {
+  if (!series.length) {
+    return <div className="h-40 rounded-2xl bg-white/5" />;
+  }
+  const values = series.map((p) => p.close);
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const range = max - min || 1;
+  const points = series
+    .map((point, index) => {
+      const x = (index / (series.length - 1 || 1)) * 100;
+      const y = ((max - point.close) / range) * 100;
+      return `${x},${y}`;
+    })
+    .join(' ');
+
+  return (
+    <svg viewBox="0 0 100 100" className="h-40 w-full rounded-2xl bg-white/5 p-2">
+      <polyline points={points} fill="none" stroke="#6BA4FF" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}

--- a/components/ChatBubble.tsx
+++ b/components/ChatBubble.tsx
@@ -1,0 +1,17 @@
+import { clsx } from 'clsx';
+
+export function ChatBubble({ role, children }: { role: 'user' | 'assistant'; children: React.ReactNode }) {
+  const isUser = role === 'user';
+  return (
+    <div className={clsx('flex w-full', isUser ? 'justify-end' : 'justify-start')}>
+      <div
+        className={clsx(
+          'max-w-[80%] rounded-2xl px-4 py-3 text-sm shadow-kachi',
+          isUser ? 'bg-kachi-accent text-kachi-shade' : 'bg-kachi-surface/90 text-kachi-textdark'
+        )}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/components/DecisionBadge.tsx
+++ b/components/DecisionBadge.tsx
@@ -1,0 +1,21 @@
+import { clsx } from 'clsx';
+
+const decisionToColor: Record<string, string> = {
+  BUY: 'bg-signal-buy/20 text-signal-buy border border-signal-buy/40',
+  SELL: 'bg-signal-sell/20 text-signal-sell border border-signal-sell/40',
+  NEUTRAL: 'bg-signal-neutral/20 text-signal-neutral border border-signal-neutral/40',
+  ABSTAIN: 'bg-kachi-accent2/20 text-kachi-accent2 border border-kachi-accent2/40'
+};
+
+export function DecisionBadge({ decision }: { decision: 'BUY' | 'SELL' | 'NEUTRAL' | 'ABSTAIN' }) {
+  return (
+    <span
+      className={clsx(
+        'inline-flex items-center rounded-full px-4 py-1 text-xs font-semibold uppercase tracking-wide',
+        decisionToColor[decision]
+      )}
+    >
+      {decision}
+    </span>
+  );
+}

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { Tabs } from '@/components/Tabs';
+import { useEffect } from 'react';
+
+const tabs = [
+  { href: '/capture', label: '📷解析' },
+  { href: '/chat', label: '💬アドバイス' },
+  { href: '/nav', label: '📈銘柄ナビ' },
+  { href: '/nisa', label: '🎓NISAサポート' },
+  { href: '/settings', label: '⚙️設定' }
+];
+
+export function Layout({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname();
+
+  useEffect(() => {
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker
+        .register('/service-worker.js')
+        .catch((error) => console.error('SW registration failed', error));
+    }
+  }, []);
+
+  return (
+    <div className="flex min-h-screen flex-col bg-kachi text-kachi-textdark">
+      <header className="flex items-center justify-between px-6 py-4 shadow-kachi">
+        <div>
+          <h1 className="text-lg font-semibold tracking-wide">NISAサポート</h1>
+          <p className="text-xs text-kachi-textdark/80">投資助言ではなく教育支援を目的としています。</p>
+        </div>
+        <Link
+          href="/settings"
+          className="rounded-full border border-kachi-accent px-3 py-1 text-xs font-semibold text-kachi-accent hover:bg-kachi-tint"
+        >
+          API設定
+        </Link>
+      </header>
+      <main className="flex-1 bg-kachi-tint/30 px-4 pb-24 pt-6 sm:px-6">{children}</main>
+      <Tabs tabs={tabs} current={pathname} />
+    </div>
+  );
+}

--- a/components/MetricChip.tsx
+++ b/components/MetricChip.tsx
@@ -1,0 +1,8 @@
+export function MetricChip({ label, value }: { label: string; value: string | number }) {
+  return (
+    <div className="flex flex-col rounded-xl bg-white/5 px-3 py-2 text-xs">
+      <span className="text-[10px] uppercase tracking-widest text-white/60">{label}</span>
+      <span className="font-semibold text-kachi-textdark">{value}</span>
+    </div>
+  );
+}

--- a/components/ScoreBar.tsx
+++ b/components/ScoreBar.tsx
@@ -1,0 +1,17 @@
+export function ScoreBar({ value }: { value: number }) {
+  const pct = Math.round(value * 100);
+  return (
+    <div className="flex flex-col gap-1">
+      <div className="flex items-center justify-between text-xs">
+        <span>信頼度</span>
+        <span>{pct}%</span>
+      </div>
+      <div className="h-2 w-full rounded-full bg-white/10">
+        <div
+          className="h-2 rounded-full bg-kachi-accent transition-all"
+          style={{ width: `${Math.min(100, Math.max(0, pct))}%` }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/components/StockCard.tsx
+++ b/components/StockCard.tsx
@@ -1,0 +1,46 @@
+import { Card } from '@/components/Card';
+import { DecisionBadge } from '@/components/DecisionBadge';
+import { ScoreBar } from '@/components/ScoreBar';
+
+interface StockCardProps {
+  symbol: string;
+  name: string;
+  decision: 'BUY' | 'SELL' | 'NEUTRAL' | 'ABSTAIN';
+  score: number;
+  expenseRatio?: number | null;
+  dividendYield?: number | null;
+  onSelect?: () => void;
+}
+
+export function StockCard({
+  symbol,
+  name,
+  decision,
+  score,
+  expenseRatio,
+  dividendYield,
+  onSelect
+}: StockCardProps) {
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      className="w-full text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-kachi-accent"
+    >
+      <Card className="flex flex-col gap-4">
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="text-sm font-semibold tracking-wide text-kachi-accent">{symbol}</p>
+            <p className="text-xs text-white/70">{name}</p>
+          </div>
+          <DecisionBadge decision={decision} />
+        </div>
+        <ScoreBar value={score} />
+        <div className="flex flex-wrap gap-3 text-xs text-white/80">
+          {expenseRatio != null && <span>経費率: {expenseRatio.toFixed(2)}%</span>}
+          {dividendYield != null && <span>配当利回り: {dividendYield.toFixed(2)}%</span>}
+        </div>
+      </Card>
+    </button>
+  );
+}

--- a/components/Tabs.tsx
+++ b/components/Tabs.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import Link from 'next/link';
+import { clsx } from 'clsx';
+
+interface TabItem {
+  href: string;
+  label: string;
+}
+
+export function Tabs({ tabs, current }: { tabs: TabItem[]; current: string }) {
+  return (
+    <nav className="fixed inset-x-0 bottom-0 border-t border-white/10 bg-kachi-shade/95 backdrop-blur">
+      <ul className="mx-auto flex max-w-3xl justify-between px-6 py-3 text-xs font-semibold text-kachi-textdark">
+        {tabs.map((tab) => {
+          const active = current.startsWith(tab.href);
+          return (
+            <li key={tab.href}>
+              <Link
+                href={tab.href}
+                className={clsx(
+                  'flex min-w-[56px] flex-col items-center rounded-xl px-3 py-2 transition-colors',
+                  active ? 'bg-kachi-tint text-kachi-accent shadow-kachi' : 'text-kachi-textdark/70 hover:text-kachi-accent'
+                )}
+              >
+                {tab.label}
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+    </nav>
+  );
+}

--- a/lib/alphavantage.ts
+++ b/lib/alphavantage.ts
@@ -1,0 +1,120 @@
+import { unstable_noStore as noStore } from 'next/cache';
+import { TTLCache } from '@/lib/cache';
+import type {
+  AlphaDailyPoint,
+  AlphaMonthlyPoint,
+  EtfProfile,
+  OverviewProfile
+} from '@/lib/types';
+
+const BASE_URL = 'https://www.alphavantage.co/query';
+const cache = new TTLCache<any>(15 * 60 * 1000);
+
+async function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function requestAlpha(endpoint: string, params: Record<string, string>, apiKey?: string, attempt = 0): Promise<any> {
+  noStore();
+  const key = apiKey ?? process.env.ALPHAVANTAGE_API_KEY;
+  if (!key) throw new Error('Alpha Vantage APIキーが設定されていません');
+  const searchParams = new URLSearchParams({ function: endpoint, apikey: key, ...params });
+  const url = `${BASE_URL}?${searchParams.toString()}`;
+  const cached = cache.get(url);
+  if (cached) return cached;
+
+  const response = await fetch(url, { cache: 'no-store' });
+  if (response.status === 429 && attempt < 5) {
+    const retryAfter = Number(response.headers.get('retry-after')) || 2 ** attempt;
+    await sleep(retryAfter * 1000);
+    return requestAlpha(endpoint, params, apiKey, attempt + 1);
+  }
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Alpha Vantageエラー: ${response.status} ${text}`);
+  }
+  const contentType = response.headers.get('content-type');
+  const data = contentType?.includes('csv') ? await response.text() : await response.json();
+  cache.set(url, data);
+  return data;
+}
+
+function parseDaily(json: any): AlphaDailyPoint[] {
+  const timeSeries = json['Time Series (Daily)'];
+  if (!timeSeries) return [];
+  return Object.entries(timeSeries).map(([date, value]: [string, any]) => ({
+    date,
+    open: Number(value['1. open']),
+    high: Number(value['2. high']),
+    low: Number(value['3. low']),
+    close: Number(value['4. close']),
+    adjustedClose: Number(value['5. adjusted close']),
+    volume: Number(value['6. volume']),
+    dividend: Number(value['7. dividend amount']),
+    splitCoefficient: Number(value['8. split coefficient'])
+  }));
+}
+
+function parseMonthly(json: any): AlphaMonthlyPoint[] {
+  const series = json['Monthly Adjusted Time Series'];
+  if (!series) return [];
+  return Object.entries(series).map(([date, value]: [string, any]) => ({
+    date,
+    close: Number(value['4. close']),
+    adjustedClose: Number(value['5. adjusted close']),
+    dividend: Number(value['7. dividend amount'])
+  }));
+}
+
+export async function fetchDailyAdjusted(symbol: string, apiKey?: string): Promise<AlphaDailyPoint[]> {
+  const data = await requestAlpha('TIME_SERIES_DAILY_ADJUSTED', { symbol, outputsize: 'full' }, apiKey);
+  return parseDaily(data).sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
+}
+
+export async function fetchMonthlyAdjusted(symbol: string, apiKey?: string): Promise<AlphaMonthlyPoint[]> {
+  const data = await requestAlpha('TIME_SERIES_MONTHLY_ADJUSTED', { symbol }, apiKey);
+  return parseMonthly(data).sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
+}
+
+export async function fetchOverview(symbol: string, apiKey?: string): Promise<OverviewProfile | null> {
+  const data = await requestAlpha('OVERVIEW', { symbol }, apiKey);
+  if (!data || !data.Symbol) return null;
+  return {
+    symbol: data.Symbol,
+    name: data.Name,
+    description: data.Description,
+    sector: data.Sector,
+    industry: data.Industry,
+    dividendPerShare: data.DividendPerShare ? Number(data.DividendPerShare) : undefined,
+    dividendYield: data.DividendYield ? Number(data.DividendYield) * 100 : undefined
+  };
+}
+
+export async function fetchEtfProfile(symbol: string, apiKey?: string): Promise<EtfProfile | null> {
+  const data = await requestAlpha('ETF_PROFILE', { symbol }, apiKey);
+  if (!data || !Array.isArray(data.data) || data.data.length === 0) return null;
+  const entry = data.data[0];
+  return {
+    symbol: entry.ticker,
+    name: entry.name,
+    expenseRatio: entry.expenseRatio ? Number(entry.expenseRatio) : undefined,
+    assetClass: entry.assetClass
+  };
+}
+
+export async function fetchSymbolSearch(keyword: string, apiKey?: string) {
+  const data = await requestAlpha('SYMBOL_SEARCH', { keywords: keyword }, apiKey);
+  const matches = data.bestMatches ?? [];
+  return matches.map((match: any) => ({
+    symbol: match['1. symbol'],
+    name: match['2. name'],
+    region: match['4. region']
+  }));
+}
+
+export async function fetchListings(apiKey?: string): Promise<string[]> {
+  const csv = await requestAlpha('LISTING_STATUS', { state: 'active' }, apiKey);
+  if (typeof csv !== 'string') return [];
+  const lines = csv.trim().split('\n');
+  return lines.slice(1).map((line) => line.split(',')[0]);
+}

--- a/lib/cache.ts
+++ b/lib/cache.ts
@@ -1,0 +1,23 @@
+interface CacheEntry<T> {
+  value: T;
+  expiry: number;
+}
+
+export class TTLCache<T> {
+  private store = new Map<string, CacheEntry<T>>();
+  constructor(private ttlMs: number) {}
+
+  get(key: string): T | undefined {
+    const entry = this.store.get(key);
+    if (!entry) return undefined;
+    if (Date.now() > entry.expiry) {
+      this.store.delete(key);
+      return undefined;
+    }
+    return entry.value;
+  }
+
+  set(key: string, value: T) {
+    this.store.set(key, { value, expiry: Date.now() + this.ttlMs });
+  }
+}

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,0 +1,24 @@
+export const THEME_COLOR = '#0F2540';
+
+export const DEFAULT_THRESHOLDS = {
+  long: {
+    buy: 5,
+    sell: -5
+  },
+  swing: {
+    buy: 4,
+    sell: -4
+  }
+};
+
+export const DISCLAIMER = '本アプリは投資助言ではなく教育目的の情報提供ツールです。投資判断はご自身の責任で行ってください。';
+
+export const STORAGE_KEY = 'nisa-support-settings';
+
+export const API_ENDPOINTS = {
+  alpha: '/api/alpha',
+  analyzePhoto: '/api/analyze-photo',
+  score: '/api/score',
+  search: '/api/search',
+  recommend: '/api/recommend'
+};

--- a/lib/indicators.ts
+++ b/lib/indicators.ts
@@ -1,0 +1,135 @@
+import type { AlphaDailyPoint, AlphaMonthlyPoint, IndicatorSet } from '@/lib/types';
+
+export function sma(values: number[], period: number): number | undefined {
+  if (values.length < period) return undefined;
+  const slice = values.slice(-period);
+  const sum = slice.reduce((acc, cur) => acc + cur, 0);
+  return sum / period;
+}
+
+export function ema(values: number[], period: number): number | undefined {
+  if (values.length < period) return undefined;
+  const k = 2 / (period + 1);
+  let emaValue = values[0];
+  for (let i = 1; i < values.length; i += 1) {
+    emaValue = values[i] * k + emaValue * (1 - k);
+  }
+  return emaValue;
+}
+
+export function rsi(data: AlphaDailyPoint[], period = 14): number | undefined {
+  if (data.length <= period) return undefined;
+  let gain = 0;
+  let loss = 0;
+  for (let i = data.length - period; i < data.length; i += 1) {
+    const change = data[i].adjustedClose - data[i - 1].adjustedClose;
+    if (change > 0) gain += change;
+    else loss -= change;
+  }
+  const avgGain = gain / period;
+  const avgLoss = loss / period;
+  if (avgLoss === 0) return 100;
+  const rs = avgGain / avgLoss;
+  return 100 - 100 / (1 + rs);
+}
+
+export function macd(data: AlphaDailyPoint[], fast = 12, slow = 26, signal = 9) {
+  if (data.length < slow + signal) return { macd: undefined, signal: undefined };
+  const closes = data.map((d) => d.adjustedClose);
+  const fastEma = ema(closes, fast);
+  const slowEma = ema(closes, slow);
+  if (fastEma === undefined || slowEma === undefined) return { macd: undefined, signal: undefined };
+  const macdValue = fastEma - slowEma;
+  const macdSeries: number[] = [];
+  for (let i = slow; i < closes.length; i += 1) {
+    const fastSlice = ema(closes.slice(0, i + 1), fast);
+    const slowSlice = ema(closes.slice(0, i + 1), slow);
+    if (fastSlice !== undefined && slowSlice !== undefined) {
+      macdSeries.push(fastSlice - slowSlice);
+    }
+  }
+  const signalValue = ema(macdSeries, signal);
+  return { macd: macdValue, signal: signalValue };
+}
+
+export function atr(data: AlphaDailyPoint[], period = 14): number | undefined {
+  if (data.length <= period) return undefined;
+  const trs: number[] = [];
+  for (let i = data.length - period; i < data.length; i += 1) {
+    const current = data[i];
+    const prev = data[i - 1];
+    const highLow = current.high - current.low;
+    const highClose = Math.abs(current.high - prev.adjustedClose);
+    const lowClose = Math.abs(current.low - prev.adjustedClose);
+    trs.push(Math.max(highLow, highClose, lowClose));
+  }
+  const sum = trs.reduce((acc, cur) => acc + cur, 0);
+  return sum / trs.length;
+}
+
+export function maxDrawdown(data: AlphaDailyPoint[]): number | undefined {
+  if (!data.length) return undefined;
+  let peak = data[0].adjustedClose;
+  let maxDd = 0;
+  for (const point of data) {
+    if (point.adjustedClose > peak) {
+      peak = point.adjustedClose;
+    }
+    const dd = (peak - point.adjustedClose) / peak;
+    if (dd > maxDd) {
+      maxDd = dd;
+    }
+  }
+  return maxDd * 100;
+}
+
+export function distFromMA(data: AlphaDailyPoint[], period: number): number | undefined {
+  const closes = data.map((d) => d.adjustedClose);
+  const ma = sma(closes, period);
+  if (ma === undefined) return undefined;
+  const latest = closes[closes.length - 1];
+  return ((latest - ma) / ma) * 100;
+}
+
+export function distFrom52wHigh(data: AlphaDailyPoint[]): number | undefined {
+  if (!data.length) return undefined;
+  const recent = data.slice(-252);
+  const high = Math.max(...recent.map((d) => d.adjustedClose));
+  const latest = recent[recent.length - 1].adjustedClose;
+  return ((high - latest) / high) * 100;
+}
+
+export function volumeRatio(data: AlphaDailyPoint[], period: number): number | undefined {
+  if (data.length < period) return undefined;
+  const recent = data.slice(-period);
+  const avg = recent.reduce((sum, item) => sum + item.volume, 0) / period;
+  const latest = data[data.length - 1].volume;
+  return latest / avg;
+}
+
+export function calcDividendYieldFromMonthlyAdjusted(data: AlphaMonthlyPoint[]): number | undefined {
+  if (data.length < 12) return undefined;
+  const recent = data.slice(-12);
+  const dividends = recent.reduce((sum, item) => sum + (item.dividend ?? 0), 0);
+  const latestClose = recent[recent.length - 1].adjustedClose;
+  if (!latestClose) return undefined;
+  return (dividends / latestClose) * 100;
+}
+
+export function buildIndicatorSet(dailies: AlphaDailyPoint[], monthlies: AlphaMonthlyPoint[]): IndicatorSet {
+  const closes = dailies.map((d) => d.adjustedClose);
+  return {
+    sma20: sma(closes, 20),
+    sma50: sma(closes, 50),
+    sma200: sma(closes, 200),
+    ema20: ema(closes, 20),
+    rsi14: rsi(dailies),
+    ...macd(dailies),
+    atr14: atr(dailies),
+    volumeRatio5: volumeRatio(dailies, 5),
+    volumeRatio20: volumeRatio(dailies, 20),
+    maxDrawdown: maxDrawdown(dailies),
+    distFrom52wHigh: distFrom52wHigh(dailies),
+    dividendYieldTrailing: calcDividendYieldFromMonthlyAdjusted(monthlies)
+  };
+}

--- a/lib/openai.ts
+++ b/lib/openai.ts
@@ -1,0 +1,254 @@
+import { unstable_noStore as noStore } from 'next/cache';
+import type { AdvicePayload, PhotoAnalysis } from '@/lib/types';
+
+const OPENAI_API_URL = 'https://api.openai.com/v1/responses';
+
+interface CallResponsesOptions {
+  apiKey?: string;
+  expectsJson?: boolean;
+}
+
+async function callResponses<T>(
+  payload: Record<string, unknown>,
+  { apiKey, expectsJson = true }: CallResponsesOptions = {}
+): Promise<T> {
+  noStore();
+  const key = apiKey ?? process.env.OPENAI_API_KEY;
+  if (!key) {
+    throw new Error('OpenAI APIキーが設定されていません');
+  }
+  const response = await fetch(OPENAI_API_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${key}`
+    },
+    body: JSON.stringify(payload)
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`OpenAI APIエラー: ${response.status} ${text}`);
+  }
+
+  const data = await response.json();
+  const firstMessage = data.output?.[0]?.content?.[0];
+  if (!firstMessage) {
+    throw new Error('OpenAI応答が不正です');
+  }
+
+  if ('json' in firstMessage && firstMessage.json) {
+    return firstMessage.json as T;
+  }
+
+  const textPayload = 'text' in firstMessage ? firstMessage.text : undefined;
+  if (typeof textPayload !== 'string') {
+    throw new Error('OpenAI応答が不正です');
+  }
+
+  if (!expectsJson) {
+    return textPayload as unknown as T;
+  }
+
+  try {
+    return JSON.parse(textPayload) as T;
+  } catch (error) {
+    throw new Error(`OpenAIのJSON応答を解析できません: ${(error as Error).message}`);
+  }
+}
+
+export async function analyzePhoto({
+  image,
+  hints,
+  apiKey
+}: {
+  image: string;
+  hints?: { symbolText?: string; exchange?: string };
+  apiKey?: string;
+}): Promise<PhotoAnalysis> {
+  const model = process.env.OPENAI_MODEL_VISION ?? 'gpt-4.1-mini';
+  const schema = {
+    type: 'object',
+    properties: {
+      chart_type: { type: 'string', enum: ['line', 'candlestick', 'bar', 'area', 'unknown'] },
+      x_axis: {
+        type: 'object',
+        properties: {
+          scale: { type: 'string' },
+          unit: { type: 'string' }
+        },
+        required: ['scale', 'unit']
+      },
+      y_axis: {
+        type: 'object',
+        properties: {
+          scale: { type: 'string' },
+          unit: { type: 'string' }
+        },
+        required: ['scale', 'unit']
+      },
+      symbol_candidates: {
+        type: 'array',
+        items: { type: 'string' }
+      },
+      timeframe: { type: 'string' },
+      annotations: {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            type: { type: 'string' },
+            period: { type: 'number' }
+          },
+          required: ['type'],
+          additionalProperties: false
+        }
+      },
+      claims: {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            text: { type: 'string' },
+            confidence: { type: 'number' }
+          },
+          required: ['text', 'confidence'],
+          additionalProperties: false
+        }
+      },
+      pitfalls: {
+        type: 'array',
+        items: { type: 'string' }
+      }
+    },
+    required: ['chart_type', 'x_axis', 'y_axis', 'symbol_candidates', 'timeframe', 'annotations', 'claims', 'pitfalls'],
+    additionalProperties: false
+  } as const;
+
+  return callResponses<PhotoAnalysis>(
+    {
+      model,
+      reasoning: { effort: 'medium' },
+      input: [
+        {
+          role: 'system',
+          content: [
+            {
+              type: 'text',
+              text: 'あなたは投資教育用のチャート解析アシスタントです。チャート画像から定義済みスキーマに沿って厳密なJSONを返却してください。'
+            }
+          ]
+        },
+        {
+          role: 'user',
+          content: [
+            { type: 'input_image', image_url: image },
+            {
+              type: 'text',
+              text: `補足ヒント: ${JSON.stringify(hints ?? {})}`
+            }
+          ]
+        }
+      ],
+      response_format: { type: 'json_schema', json_schema: { name: 'chart_payload', schema } }
+    },
+    { apiKey, expectsJson: true }
+  );
+}
+
+export async function formatAdvice({
+  decision,
+  reasons,
+  counters,
+  nextSteps,
+  apiKey
+}: {
+  decision: string;
+  reasons: string[];
+  counters: string[];
+  nextSteps: string[];
+  apiKey?: string;
+}): Promise<AdvicePayload> {
+  const model = process.env.OPENAI_MODEL_TEXT ?? 'gpt-4.1-mini';
+  const schema = {
+    type: 'object',
+    properties: {
+      headline: { type: 'string' },
+      rationale: { type: 'array', items: { type: 'string' }, minItems: 3, maxItems: 3 },
+      counterpoints: { type: 'array', items: { type: 'string' }, minItems: 2, maxItems: 2 },
+      next_steps: { type: 'array', items: { type: 'string' }, minItems: 2, maxItems: 3 },
+      disclaimer: { type: 'string' }
+    },
+    required: ['headline', 'rationale', 'counterpoints', 'next_steps', 'disclaimer'],
+    additionalProperties: false
+  } as const;
+
+  return callResponses<AdvicePayload>(
+    {
+      model,
+      input: [
+        {
+          role: 'system',
+          content: [
+            {
+              type: 'text',
+              text: 'あなたは投資教育アシスタント。売買指示は出さず、提供されたシグナルを教育的に説明します。反対要因と免責を必ず含めてください。'
+            }
+          ]
+        },
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({ decision, reasons, counters, nextSteps })
+            }
+          ]
+        }
+      ],
+      response_format: { type: 'json_schema', json_schema: { name: 'advice_payload', schema } }
+    },
+    { apiKey, expectsJson: true }
+  );
+}
+
+export async function chatEducator({
+  messages,
+  apiKey
+}: {
+  messages: { role: 'user' | 'assistant'; content: string }[];
+  apiKey?: string;
+}): Promise<string> {
+  const model = process.env.OPENAI_MODEL_TEXT ?? 'gpt-4.1-mini';
+  const response = await callResponses<string>(
+    {
+      model,
+      input: [
+        {
+          role: 'system',
+          content: [
+            {
+              type: 'text',
+              text: 'あなたは長期投資教育アシスタント。特定の売買指示は出さず、データとリスクを比較しながら解説してください。常に免責を添えてください。'
+            }
+          ]
+        },
+        ...messages.map((message) => ({
+          role: message.role,
+          content: [{ type: 'text', text: message.content }]
+        })),
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'text',
+              text: '最後に短い免責を追加してください。'
+            }
+          ]
+        }
+      ]
+    },
+    { apiKey, expectsJson: false }
+  );
+  return response?.trim() ? response : '申し訳ありません、回答を生成できませんでした。';
+}

--- a/lib/reconcile.ts
+++ b/lib/reconcile.ts
@@ -1,0 +1,29 @@
+import type { PhotoAnalysis, AlphaDailyPoint } from '@/lib/types';
+
+export function reconcileSymbol(photo: PhotoAnalysis, fallback: string | null, universe: string[]): string | null {
+  const candidates = [...(photo.symbol_candidates ?? [])];
+  if (fallback) candidates.unshift(fallback);
+  const normalized = candidates.map((sym) => sym.trim().toUpperCase());
+  for (const candidate of normalized) {
+    if (universe.includes(candidate)) {
+      return candidate;
+    }
+  }
+  return normalized[0] ?? null;
+}
+
+export function detectAnomalies(dailies: AlphaDailyPoint[]): string[] {
+  const alerts: string[] = [];
+  for (let i = 1; i < dailies.length; i += 1) {
+    const prev = dailies[i - 1];
+    const current = dailies[i];
+    const gap = Math.abs(current.adjustedClose - prev.adjustedClose) / prev.adjustedClose;
+    if (gap > 0.2) {
+      alerts.push(`価格ギャップ検出: ${(gap * 100).toFixed(1)}%`);
+    }
+    if (current.splitCoefficient && current.splitCoefficient !== 1) {
+      alerts.push(`分割イベント: ${current.splitCoefficient}`);
+    }
+  }
+  return alerts;
+}

--- a/lib/scoring.ts
+++ b/lib/scoring.ts
@@ -1,0 +1,173 @@
+import { DEFAULT_THRESHOLDS } from '@/lib/constants';
+import type {
+  AlphaDailyPoint,
+  AlphaMonthlyPoint,
+  EtfProfile,
+  IndicatorSet,
+  OverviewProfile,
+  ScoreReason,
+  ScoreResult
+} from '@/lib/types';
+
+interface DecideInput {
+  metrics: IndicatorSet;
+  dailies: AlphaDailyPoint[];
+  monthlies: AlphaMonthlyPoint[];
+  mode: 'long' | 'swing';
+  profile?: EtfProfile | null;
+  overview?: OverviewProfile | null;
+  anomalies?: string[];
+}
+
+function pushReason(list: ScoreReason[], label: string, weight: number) {
+  list.push({ label, weight });
+}
+
+export function decide({ metrics, dailies, monthlies, mode, profile, overview, anomalies }: DecideInput): ScoreResult {
+  if (!dailies.length || !monthlies.length || anomalies?.length) {
+    return {
+      decision: 'ABSTAIN',
+      confidence: 0.1,
+      reasons: anomalies?.map((text) => ({ label: text, weight: -1 })) ?? [],
+      counters: [],
+      metrics,
+      horizon: mode
+    };
+  }
+
+  const latest = dailies[dailies.length - 1];
+  const prev = dailies[dailies.length - 2];
+  const positives: ScoreReason[] = [];
+  const negatives: ScoreReason[] = [];
+  let score = 0;
+
+  if (metrics.sma200 !== undefined) {
+    if (latest.adjustedClose > metrics.sma200) {
+      score += 2;
+      pushReason(positives, `+2: 終値がSMA200(${metrics.sma200.toFixed(2)})を上回る`, 2);
+    } else {
+      score -= 2;
+      pushReason(negatives, `-2: 終値がSMA200(${metrics.sma200.toFixed(2)})を下回る`, -2);
+    }
+  }
+
+  if (metrics.sma50 !== undefined && metrics.sma200 !== undefined) {
+    if (metrics.sma50 > metrics.sma200) {
+      score += 2;
+      pushReason(positives, '+2: SMA50がSMA200を上抜け', 2);
+    } else {
+      score -= 2;
+      pushReason(negatives, '-2: SMA50がSMA200を下回る', -2);
+    }
+  }
+
+  if (metrics.sma20 !== undefined && metrics.sma50 !== undefined) {
+    if (metrics.sma20 > metrics.sma50) {
+      score += 1;
+      pushReason(positives, '+1: SMA20がSMA50を上回る', 1);
+    } else {
+      score -= 1;
+      pushReason(negatives, '-1: SMA20がSMA50を下回る', -1);
+    }
+  }
+
+  const rsi = metrics.rsi14;
+  if (rsi !== undefined) {
+    const upper = mode === 'swing' ? 65 : 70;
+    if (rsi >= 45 && rsi <= 60) {
+      score += 1;
+      pushReason(positives, `+1: RSI14が健全圏(${rsi.toFixed(1)})`, 1);
+    } else if (rsi < 35) {
+      score -= 2;
+      pushReason(negatives, `-2: RSI14が売られすぎ(${rsi.toFixed(1)})`, -2);
+    } else if (rsi > upper) {
+      score -= 2;
+      pushReason(negatives, `-2: RSI14が過熱(${rsi.toFixed(1)})`, -2);
+    }
+  }
+
+  if (metrics.macd !== undefined && metrics.macdSignal !== undefined) {
+    if (metrics.macd > metrics.macdSignal) {
+      score += 1;
+      pushReason(positives, '+1: MACDがシグナルを上抜け', 1);
+    } else {
+      score -= 1;
+      pushReason(negatives, '-1: MACDがシグナルを下回る', -1);
+    }
+  }
+
+  if (metrics.atr14 !== undefined) {
+    const atrRatio = (metrics.atr14 / latest.adjustedClose) * 100;
+    const priceChange = ((latest.adjustedClose - prev.adjustedClose) / prev.adjustedClose) * 100;
+    if (atrRatio > 5 && priceChange < 0) {
+      score -= 2;
+      pushReason(negatives, `-2: ボラティリティ高騰 ATR比 ${atrRatio.toFixed(1)}%`, -2);
+    } else if (atrRatio < 3 && priceChange > 0) {
+      score += 1;
+      pushReason(positives, `+1: 安定した上昇 ATR比 ${atrRatio.toFixed(1)}%`, 1);
+    }
+  }
+
+  if (metrics.volumeRatio5 !== undefined && metrics.volumeRatio20 !== undefined) {
+    if (metrics.volumeRatio5 > 1.5 && latest.adjustedClose > prev.adjustedClose) {
+      score += 2;
+      pushReason(positives, `+2: 出来高急増 ${metrics.volumeRatio5.toFixed(2)}x`, 2);
+    } else if (metrics.volumeRatio5 > 1.5 && latest.adjustedClose < prev.adjustedClose) {
+      score -= 2;
+      pushReason(negatives, `-2: 出来高増で下落 ${metrics.volumeRatio5.toFixed(2)}x`, -2);
+    }
+  }
+
+  if (metrics.distFrom52wHigh !== undefined) {
+    if (metrics.distFrom52wHigh < 10) {
+      score += 1;
+      pushReason(positives, `+1: 52週高値乖離 ${metrics.distFrom52wHigh.toFixed(1)}%`, 1);
+    } else if (metrics.distFrom52wHigh > 25) {
+      score -= 1;
+      pushReason(negatives, `-1: 52週高値からの乖離 ${metrics.distFrom52wHigh.toFixed(1)}%`, -1);
+    }
+  }
+
+  if (metrics.maxDrawdown !== undefined && metrics.maxDrawdown > 25) {
+    score -= 1;
+    pushReason(negatives, `-1: 直近最大ドローダウン ${metrics.maxDrawdown.toFixed(1)}%`, -1);
+  }
+
+  const dividend = metrics.dividendYieldTrailing ?? overview?.dividendYield;
+  if (dividend !== undefined) {
+    if (dividend > 3) {
+      score += 1;
+      pushReason(positives, `+1: 配当利回り ${dividend.toFixed(2)}%`, 1);
+    }
+  }
+
+  const expense = profile?.expenseRatio;
+  if (expense !== undefined) {
+    if (expense > 0.6) {
+      score -= 1;
+      pushReason(negatives, `-1: 経費率が高い ${expense.toFixed(2)}%`, -1);
+    } else if (expense < 0.2) {
+      score += 1;
+      pushReason(positives, `+1: 低コストETF ${expense.toFixed(2)}%`, 1);
+    }
+  }
+
+  const thresholds = mode === 'long' ? DEFAULT_THRESHOLDS.long : DEFAULT_THRESHOLDS.swing;
+  let decision: ScoreResult['decision'] = 'NEUTRAL';
+  if (score >= thresholds.buy) {
+    decision = 'BUY';
+  } else if (score <= thresholds.sell) {
+    decision = 'SELL';
+  }
+
+  const confidence = Math.min(0.95, Math.max(0.15, Math.abs(score) / 10 + (decision === 'NEUTRAL' ? 0.1 : 0.2)));
+
+  return {
+    decision,
+    confidence,
+    reasons: positives,
+    counters: negatives,
+    metrics,
+    horizon: mode
+  };
+}

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -1,0 +1,77 @@
+'use client';
+
+import { DEFAULT_THRESHOLDS, STORAGE_KEY } from '@/lib/constants';
+import type { AppSettings } from '@/lib/types';
+
+const SECRET_KEY = 'nisa-support-secret';
+
+async function deriveCryptoKey(secret: string, salt: Uint8Array) {
+  const enc = new TextEncoder();
+  const baseKey = await window.crypto.subtle.importKey('raw', enc.encode(secret), 'PBKDF2', false, ['deriveKey']);
+  return window.crypto.subtle.deriveKey(
+    {
+      name: 'PBKDF2',
+      salt,
+      iterations: 120_000,
+      hash: 'SHA-256'
+    },
+    baseKey,
+    { name: 'AES-GCM', length: 256 },
+    false,
+    ['encrypt', 'decrypt']
+  );
+}
+
+function getOrCreateSecret() {
+  let secret = window.localStorage.getItem(SECRET_KEY);
+  if (!secret) {
+    const random = window.crypto.getRandomValues(new Uint8Array(32));
+    secret = btoa(String.fromCharCode(...Array.from(random)));
+    window.localStorage.setItem(SECRET_KEY, secret);
+  }
+  return secret;
+}
+
+export async function saveSettings(settings: AppSettings) {
+  const secret = getOrCreateSecret();
+  const salt = window.crypto.getRandomValues(new Uint8Array(16));
+  const key = await deriveCryptoKey(secret, salt);
+  const iv = window.crypto.getRandomValues(new Uint8Array(12));
+  const payload = new TextEncoder().encode(JSON.stringify(settings));
+  const cipher = await window.crypto.subtle.encrypt({ name: 'AES-GCM', iv }, key, payload);
+  const buffer = new Uint8Array(cipher);
+  const packed = new Uint8Array(salt.length + iv.length + buffer.length);
+  packed.set(salt, 0);
+  packed.set(iv, salt.length);
+  packed.set(buffer, salt.length + iv.length);
+  const encoded = btoa(String.fromCharCode(...Array.from(packed)));
+  window.localStorage.setItem(STORAGE_KEY, encoded);
+}
+
+export async function loadSettings(): Promise<AppSettings | null> {
+  const encoded = window.localStorage.getItem(STORAGE_KEY);
+  if (!encoded) return null;
+  try {
+    const secret = getOrCreateSecret();
+    const packed = Uint8Array.from(atob(encoded), (c) => c.charCodeAt(0));
+    const salt = packed.slice(0, 16);
+    const iv = packed.slice(16, 28);
+    const data = packed.slice(28);
+    const key = await deriveCryptoKey(secret, salt);
+    const decrypted = await window.crypto.subtle.decrypt({ name: 'AES-GCM', iv }, key, data);
+    const decoded = new TextDecoder().decode(decrypted);
+    return JSON.parse(decoded) as AppSettings;
+  } catch (error) {
+    console.error('Failed to decode settings', error);
+    return null;
+  }
+}
+
+export function defaultSettings(): AppSettings {
+  return {
+    thresholds: DEFAULT_THRESHOLDS,
+    mode: 'long',
+    theme: 'system',
+    acceptedDisclaimer: false
+  };
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,0 +1,105 @@
+export type Decision = 'BUY' | 'SELL' | 'NEUTRAL' | 'ABSTAIN';
+
+export interface ChartAnnotation {
+  type: string;
+  period?: number;
+}
+
+export interface ChartClaim {
+  text: string;
+  confidence: number;
+}
+
+export interface PhotoAnalysis {
+  chart_type: 'line' | 'candlestick' | 'bar' | 'area' | 'unknown';
+  x_axis: { scale: string; unit: string };
+  y_axis: { scale: string; unit: string };
+  symbol_candidates: string[];
+  timeframe: string;
+  annotations: ChartAnnotation[];
+  claims: ChartClaim[];
+  pitfalls: string[];
+}
+
+export interface AlphaDailyPoint {
+  date: string;
+  open: number;
+  high: number;
+  low: number;
+  close: number;
+  adjustedClose: number;
+  volume: number;
+  dividend: number;
+  splitCoefficient: number;
+}
+
+export interface AlphaMonthlyPoint {
+  date: string;
+  close: number;
+  adjustedClose: number;
+  dividend: number;
+}
+
+export interface EtfProfile {
+  symbol: string;
+  name: string;
+  expenseRatio?: number;
+  assetClass?: string;
+}
+
+export interface OverviewProfile {
+  symbol: string;
+  name: string;
+  description?: string;
+  sector?: string;
+  industry?: string;
+  dividendPerShare?: number;
+  dividendYield?: number;
+}
+
+export interface IndicatorSet {
+  sma20?: number;
+  sma50?: number;
+  sma200?: number;
+  ema20?: number;
+  rsi14?: number;
+  macd?: number;
+  macdSignal?: number;
+  atr14?: number;
+  volumeRatio5?: number;
+  volumeRatio20?: number;
+  maxDrawdown?: number;
+  distFrom52wHigh?: number;
+  dividendYieldTrailing?: number;
+}
+
+export interface ScoreReason {
+  label: string;
+  weight: number;
+}
+
+export interface ScoreResult {
+  decision: Decision;
+  confidence: number;
+  reasons: ScoreReason[];
+  counters: ScoreReason[];
+  metrics: IndicatorSet;
+  horizon: 'long' | 'swing';
+}
+
+export interface AdvicePayload {
+  headline: string;
+  rationale: string[];
+  counterpoints: string[];
+  next_steps: string[];
+  disclaimer: string;
+}
+
+export interface AppSettings {
+  openAIApiKey?: string;
+  alphaVantageApiKey?: string;
+  thresholds: typeof import('./constants').DEFAULT_THRESHOLDS;
+  mode: 'long' | 'swing';
+  theme: 'system' | 'light' | 'dark';
+  acceptedDisclaimer: boolean;
+}

--- a/lib/useAppSettings.ts
+++ b/lib/useAppSettings.ts
@@ -1,0 +1,26 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { defaultSettings, loadSettings, saveSettings } from '@/lib/storage';
+import type { AppSettings } from '@/lib/types';
+
+export function useAppSettings() {
+  const [settings, setSettings] = useState<AppSettings>(defaultSettings());
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    loadSettings().then((stored) => {
+      if (stored) {
+        setSettings(stored);
+      }
+      setReady(true);
+    });
+  }, []);
+
+  const update = async (next: AppSettings) => {
+    setSettings(next);
+    await saveSettings(next);
+  };
+
+  return { settings, setSettings: update, ready };
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,18 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    serverActions: {
+      bodySizeLimit: '4mb'
+    }
+  },
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: '**'
+      }
+    ]
+  }
+};
+
+module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "nisa-support",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "@headlessui/react": "^1.7.17",
+    "@heroicons/react": "^2.1.1",
+    "clsx": "^2.1.1",
+    "framer-motion": "^11.0.17",
+    "next": "14.1.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "swr": "^2.2.4"
+  },
+  "devDependencies": {
+    "@types/node": "20.11.24",
+    "@types/react": "18.2.56",
+    "@types/react-dom": "18.2.19",
+    "autoprefixer": "10.4.17",
+    "eslint": "8.57.0",
+    "eslint-config-next": "14.1.0",
+    "postcss": "8.4.35",
+    "tailwindcss": "3.4.1",
+    "typescript": "5.3.3"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/public/i18n/ja.json
+++ b/public/i18n/ja.json
@@ -1,0 +1,37 @@
+{
+  "capture": {
+    "title": "チャート解析",
+    "upload": "写真をアップロード",
+    "analyzing": "解析中...",
+    "recalculate": "再計算",
+    "education": "このシグナルは教育目的であり、投資助言ではありません。"
+  },
+  "chat": {
+    "title": "AIアドバイス",
+    "placeholder": "質問を入力（例：SPYのリスクは？）"
+  },
+  "nav": {
+    "title": "銘柄ナビ",
+    "popular": "人気",
+    "etf": "おすすめETF",
+    "buy": "買い時候補"
+  },
+  "nisa": {
+    "title": "NISAサポート",
+    "overview": "制度の概要",
+    "qa": "よくある質問",
+    "steps": "学習ステップ",
+    "simulator": "簡易シミュレーション"
+  },
+  "settings": {
+    "title": "設定",
+    "openai": "OpenAI APIキー",
+    "alpha": "Alpha Vantage APIキー",
+    "mode": "分析モード",
+    "theme": "テーマ",
+    "disclaimer": "免責へ同意する",
+    "save": "保存",
+    "long": "長期",
+    "swing": "スイング"
+  }
+}

--- a/public/icons/icon-192.svg
+++ b/public/icons/icon-192.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 192 192">
+  <defs>
+    <linearGradient id="bg192" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0F2540" />
+      <stop offset="100%" stop-color="#163253" />
+    </linearGradient>
+  </defs>
+  <rect width="192" height="192" rx="36" fill="url(#bg192)" />
+  <g fill="none" stroke="#C7A66B" stroke-width="8" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M44 124c18-30 78-30 104 0" />
+    <path d="M56 80h22l15-24 15 48 12-24h26" />
+  </g>
+  <circle cx="62" cy="74" r="6" fill="#6BA4FF" />
+  <circle cx="130" cy="124" r="7" fill="#6BA4FF" />
+  <text x="96" y="152" text-anchor="middle" font-family="'K2D', 'Noto Sans JP', sans-serif" font-size="30" font-weight="700" fill="#F2F5FA">NISA</text>
+</svg>

--- a/public/icons/icon-512.svg
+++ b/public/icons/icon-512.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0F2540" />
+      <stop offset="100%" stop-color="#163253" />
+    </linearGradient>
+  </defs>
+  <rect width="512" height="512" rx="96" fill="url(#bg)" />
+  <g fill="none" stroke="#C7A66B" stroke-width="20" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M128 320c48-80 208-80 256 0" />
+    <path d="M160 208h56l40-64 40 128 32-64h64" />
+  </g>
+  <circle cx="168" cy="192" r="16" fill="#6BA4FF" />
+  <circle cx="344" cy="320" r="18" fill="#6BA4FF" />
+  <text x="256" y="404" text-anchor="middle" font-family="'K2D', 'Noto Sans JP', sans-serif" font-size="72" font-weight="700" fill="#F2F5FA">NISA</text>
+</svg>

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,0 +1,13 @@
+{
+  "name": "NISAサポート",
+  "short_name": "NISA",
+  "start_url": "/capture",
+  "display": "standalone",
+  "background_color": "#0F2540",
+  "theme_color": "#0F2540",
+  "lang": "ja",
+  "icons": [
+    { "src": "/icons/icon-192.svg", "sizes": "192x192", "type": "image/svg+xml", "purpose": "any" },
+    { "src": "/icons/icon-512.svg", "sizes": "512x512", "type": "image/svg+xml", "purpose": "any" }
+  ]
+}

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,0 +1,50 @@
+const CACHE_NAME = 'NISAサポート-static-v1';
+const ASSET_URLS = [
+  '/',
+  '/capture',
+  '/manifest.webmanifest'
+];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches
+      .open(CACHE_NAME)
+      .then((cache) => cache.addAll(ASSET_URLS))
+      .then(() => self.skipWaiting())
+  );
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches
+      .keys()
+      .then((keys) =>
+        Promise.all(
+          keys
+            .filter((key) => key !== CACHE_NAME)
+            .map((key) => caches.delete(key))
+        )
+      )
+      .then(() => self.clients.claim())
+  );
+});
+
+self.addEventListener('fetch', (event) => {
+  const { request } = event;
+  if (request.url.includes('/api/')) {
+    event.respondWith(fetch(request));
+    return;
+  }
+  event.respondWith(
+    caches.match(request).then((cached) => {
+      const fetchPromise = fetch(request).then((response) => {
+        if (response && response.status === 200 && response.type === 'basic') {
+          const cloned = response.clone();
+          caches.open(CACHE_NAME).then((cache) => cache.put(request, cloned));
+        }
+        return response;
+      });
+      return cached || fetchPromise;
+    })
+  );
+});

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,31 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './app/**/*.{js,ts,jsx,tsx}',
+    './components/**/*.{js,ts,jsx,tsx}',
+    './lib/**/*.{js,ts,jsx,tsx}'
+  ],
+  theme: {
+    extend: {
+      colors: {
+        kachi: {
+          DEFAULT: '#0F2540',
+          shade: '#0B1B31',
+          tint: '#163253',
+          accent: '#6BA4FF',
+          accent2: '#C7A66B',
+          surface: '#F7F8FA',
+          textdark: '#F2F5FA'
+        },
+        signal: {
+          buy: '#1B998B',
+          sell: '#F45B69',
+          neutral: '#FFB400'
+        }
+      },
+      boxShadow: {
+        kachi: '0 10px 30px -15px rgba(15, 37, 64, 0.4)'
+      }
+    }
+  }
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,40 @@
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "types": [
+      "node"
+    ],
+    "baseUrl": ".",
+    "paths": {
+      "@/*": [
+        "*"
+      ]
+    }
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    "**/*.cjs"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}


### PR DESCRIPTION
## Summary
- add options to the OpenAI Responses helper so we only JSON.parse content when structured output is requested
- update the analyze/advice helpers to opt into structured responses and let chat completions return plain text
- provide a defensive fallback message when the chat endpoint receives an empty reply

## Testing
- `npm run lint` *(fails: Next.js CLI is unavailable without installing dependencies in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cf96510414832fa4a4d8db926efce2