### PR TITLE
Refine OpenAI response handling

### DIFF
--- a/lib/openai.ts
+++ b/lib/openai.ts
@@ -10,10 +10,8 @@ interface CallResponsesOptions {
 
 async function callResponses<T>(
   payload: Record<string, unknown>,
-  { apiKey, expectsJson = true }: CallResponsesOptions = {}
+  { apiKey, expectsJson = true }: CallResponsesOptions = {},
 ): Promise<T> {
-=======
-async function callResponses<T>(payload: Record<string, unknown>, apiKey?: string): Promise<T> {
   noStore();
   const key = apiKey ?? process.env.OPENAI_API_KEY;
   if (!key) {
@@ -43,7 +41,11 @@ async function callResponses<T>(payload: Record<string, unknown>, apiKey?: strin
     return firstMessage.json as T;
   }
 
-  const textPayload = 'text' in firstMessage ? firstMessage.text : undefined;
+  const textPayload =
+    typeof firstMessage === 'object' && firstMessage !== null && 'text' in firstMessage
+      ? (firstMessage as { text?: unknown }).text
+      : undefined;
+
   if (typeof textPayload !== 'string') {
     throw new Error('OpenAI応答が不正です');
   }
@@ -57,12 +59,6 @@ async function callResponses<T>(payload: Record<string, unknown>, apiKey?: strin
   } catch (error) {
     throw new Error(`OpenAIのJSON応答を解析できません: ${(error as Error).message}`);
   }
-=======
-  const output = data.output?.[0]?.content?.[0]?.text ?? data.output?.[0]?.content?.[0]?.json;
-  if (!output) {
-    throw new Error('OpenAI応答が不正です');
-  }
-  return typeof output === 'string' ? (JSON.parse(output) as T) : (output as T);
 }
 
 export async function analyzePhoto({
@@ -161,8 +157,6 @@ export async function analyzePhoto({
       response_format: { type: 'json_schema', json_schema: { name: 'chart_payload', schema } }
     },
     { apiKey, expectsJson: true }
-=======
-    apiKey
   );
 }
 
@@ -219,8 +213,6 @@ export async function formatAdvice({
       response_format: { type: 'json_schema', json_schema: { name: 'advice_payload', schema } }
     },
     { apiKey, expectsJson: true }
-=======
-    apiKey
   );
 }
 
@@ -263,8 +255,4 @@ export async function chatEducator({
     { apiKey, expectsJson: false }
   );
   return response?.trim() ? response : '申し訳ありません、回答を生成できませんでした。';
-=======
-    apiKey
-  );
-  return response;
 }


### PR DESCRIPTION
## Summary
- resolve merge conflict in `lib/openai.ts` by consolidating the `callResponses` helper with options support
- update `analyzePhoto`, `formatAdvice`, and `chatEducator` to match the new helper signature
- harden response parsing so callers can request either JSON or text safely

## Testing
- npm run lint *(fails: `next` command not found because dependencies are unavailable in the environment)*
- npm install *(fails: 403 Forbidden when fetching `@headlessui/react` from the npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68cfaad00180832fafeebb4cdbac0af3