### PR TITLE
Add threshold inputs to settings

### DIFF
--- a/public/i18n/ja.json
+++ b/public/i18n/ja.json
@@ -32,6 +32,14 @@
     "disclaimer": "免責へ同意する",
     "save": "保存",
     "long": "長期",
-    "swing": "スイング"
+    "swing": "スイング",
+    "thresholds": {
+      "title": "スコア閾値",
+      "description": "BUY/SELL 判定に用いるスコアの閾値を設定します（-10〜+10、0.1刻み）",
+      "longBuy": "長期 BUY閾値",
+      "longSell": "長期 SELL閾値",
+      "swingBuy": "スイング BUY閾値",
+      "swingSell": "スイング SELL閾値"
+    }
   }
 }


### PR DESCRIPTION
## Summary
- add numeric inputs for long-term and swing buy/sell score thresholds on the settings page
- synchronize input state with local settings so values persist through the existing save flow
- update Japanese copy with labels and guidance for configuring the thresholds

## Testing
- npm run lint *(fails: dependencies cannot be installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cfba0eccac832fa2dd0e5ae9260596