### PR TITLE
Handle missing Alpha Vantage key gracefully

### DIFF
--- a/app/(tabs)/nav/page.tsx
+++ b/app/(tabs)/nav/page.tsx
@@ -26,11 +26,19 @@ export default function NavPage() {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    if (!ready || !settings.alphaVantageApiKey) return;
+    if (!ready) return;
+
+    const apiKey = settings.alphaVantageApiKey;
+    if (!apiKey) {
+      setError('Alpha Vantage API key is required to load recommendations.');
+      return;
+    }
+
+    setError(null);
     const controller = new AbortController();
     const fetchData = async () => {
       try {
-        const res = await fetch(`/api/recommend?apiKey=${encodeURIComponent(settings.alphaVantageApiKey)}&mode=${settings.mode}`, {
+        const res = await fetch(`/api/recommend?apiKey=${encodeURIComponent(apiKey)}&mode=${settings.mode}`, {
           signal: controller.signal
         });
         if (!res.ok) throw new Error(await res.text());

--- a/lib/openai.ts
+++ b/lib/openai.ts
@@ -154,7 +154,9 @@ export async function analyzePhoto({
           ]
         }
       ],
-      response_format: { type: 'json_schema', json_schema: { name: 'chart_payload', schema } }
+      text: {
+        format: { type: 'json_schema', json_schema: { name: 'chart_payload', schema } }
+      }
     },
     { apiKey, expectsJson: true }
   );
@@ -210,7 +212,9 @@ export async function formatAdvice({
           ]
         }
       ],
-      response_format: { type: 'json_schema', json_schema: { name: 'advice_payload', schema } }
+      text: {
+        format: { type: 'json_schema', json_schema: { name: 'advice_payload', schema } }
+      }
     },
     { apiKey, expectsJson: true }
   );


### PR DESCRIPTION
## Summary
- guard the recommendations fetch effect until settings are loaded
- surface a clear error when the Alpha Vantage API key is absent and reset the error state before refetching
- update OpenAI Responses payloads to use the new `text.format` JSON schema option

## Testing
- npm run build *(fails to download the K2D font from Google Fonts in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d145cee6d0832f822c4e25efeaa7c6