### PR TITLE
Remove duplicated format properties from OpenAI responses

### DIFF
--- a/lib/openai.ts
+++ b/lib/openai.ts
@@ -248,7 +248,6 @@ export async function analyzePhoto({
           name: 'chart_payload',
           json_schema: { name: 'chart_payload', schema }
         }
-        format: { type: 'json_schema', json_schema: { name: 'chart_payload', schema } }
       }
     },
     { apiKey, expectsJson: true }
@@ -311,7 +310,6 @@ export async function formatAdvice({
           name: 'advice_payload',
           json_schema: { name: 'advice_payload', schema }
         }
-        format: { type: 'json_schema', json_schema: { name: 'advice_payload', schema } }
       }
     },
     { apiKey, expectsJson: true }


### PR DESCRIPTION
## Summary
- remove the extraneous `format` properties left after a merge in the analyzePhoto and formatAdvice response payloads

## Testing
- `CI=1 npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68d1ebfde8fc832f9a7dbec40a683e99