### PR TITLE
Expose schema in OpenAI format payloads

### DIFF
--- a/lib/openai.ts
+++ b/lib/openai.ts
@@ -245,8 +245,10 @@ export async function analyzePhoto({
       text: {
         format: {
           type: 'json_schema',
-          name: 'chart_payload',
-          schema
+          json_schema: {
+            name: 'chart_payload',
+            schema
+          }
         }
       }
     },
@@ -307,8 +309,10 @@ export async function formatAdvice({
       text: {
         format: {
           type: 'json_schema',
-          name: 'advice_payload',
-          schema
+          json_schema: {
+            name: 'advice_payload',
+            schema
+          }
         }
       }
     },


### PR DESCRIPTION
## Summary
- expose the JSON schema directly on the OpenAI text.format payload for chart and advice responses

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d1f099c26c832f904c0b4743313aed