### PR TITLE
Fix OpenAI payload schema for image analysis

### DIFF
--- a/lib/openai.ts
+++ b/lib/openai.ts
@@ -234,7 +234,12 @@ export async function analyzePhoto({
         {
           role: 'user',
           content: [
-            { type: 'input_image', image_url: image },
+            {
+              type: 'input_image',
+              image_url: {
+                url: image
+              }
+            },
             {
               type: 'input_text',
               text: `補足ヒント: ${JSON.stringify(hints ?? {})}`
@@ -242,13 +247,11 @@ export async function analyzePhoto({
           ]
         }
       ],
-      text: {
-        format: {
-          type: 'json_schema',
-          json_schema: {
-            name: 'chart_payload',
-            schema
-          }
+      response_format: {
+        type: 'json_schema',
+        json_schema: {
+          name: 'chart_payload',
+          schema
         }
       }
     },
@@ -306,13 +309,11 @@ export async function formatAdvice({
           ]
         }
       ],
-      text: {
-        format: {
-          type: 'json_schema',
-          json_schema: {
-            name: 'advice_payload',
-            schema
-          }
+      response_format: {
+        type: 'json_schema',
+        json_schema: {
+          name: 'advice_payload',
+          schema
         }
       }
     },


### PR DESCRIPTION
## Summary
- fix the image upload payload to use the correct input_image structure for the Responses API
- request JSON schema outputs through the proper response_format field for photo analysis and advice generation

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d89dc00418832f8cb667f2c0749fee