### PR TITLE
Fix Responses payload for chart analysis

### DIFF
--- a/lib/openai.ts
+++ b/lib/openai.ts
@@ -102,6 +102,31 @@ interface CallResponsesOptions {
   expectsJson?: boolean;
 }
 
+const collectModalities = (content: unknown[]): Set<'text' | 'vision'> => {
+  const modes = new Set<'text' | 'vision'>();
+
+  for (const item of content) {
+    if (!isObject(item)) {
+      continue;
+    }
+
+    const type = (item as { type?: unknown }).type;
+    if (type === 'input_image' || type === 'image' || type === 'image_url') {
+      modes.add('vision');
+    } else {
+      modes.add('text');
+    }
+
+    if ('content' in item && Array.isArray((item as { content?: unknown }).content)) {
+      for (const nested of collectModalities((item as { content: unknown[] }).content)) {
+        modes.add(nested);
+      }
+    }
+  }
+
+  return modes;
+};
+
 async function callResponses<T>(
   payload: Record<string, unknown>,
   { apiKey, expectsJson = true }: CallResponsesOptions = {},
@@ -111,6 +136,42 @@ async function callResponses<T>(
   if (!key) {
     throw new Error('OpenAI APIキーが設定されていません');
   }
+
+  if (!('modalities' in payload)) {
+    const input = payload.input;
+    if (Array.isArray(input)) {
+      const derived = new Set<'text' | 'vision'>();
+      for (const message of input) {
+        if (!isObject(message)) {
+          continue;
+        }
+        const content = (message as { content?: unknown }).content;
+        if (Array.isArray(content)) {
+          for (const mode of collectModalities(content)) {
+            derived.add(mode);
+          }
+        }
+      }
+
+      if (expectsJson || derived.has('text')) {
+        derived.add('text');
+      }
+
+      if (derived.size > 0) {
+        payload.modalities = Array.from(derived);
+      }
+    } else if (expectsJson) {
+      payload.modalities = ['text'];
+    }
+  }
+
+  if (expectsJson) {
+    const textConfig = payload.text;
+    if (!isObject(textConfig) || !('format' in (textConfig as Record<string, unknown>))) {
+      payload.text = { format: 'json' };
+    }
+  }
+
   const response = await fetch(OPENAI_API_URL, {
     method: 'POST',
     headers: {
@@ -221,6 +282,7 @@ export async function analyzePhoto({
     {
       model,
       reasoning: { effort: 'medium' },
+      modalities: ['text', 'vision'],
       input: [
         {
           role: 'system',
@@ -234,7 +296,12 @@ export async function analyzePhoto({
         {
           role: 'user',
           content: [
-            { type: 'input_image', image_url: image },
+            {
+              type: 'input_image',
+              image_url: {
+                url: image
+              }
+            },
             {
               type: 'input_text',
               text: `補足ヒント: ${JSON.stringify(hints ?? {})}`
@@ -286,6 +353,7 @@ export async function formatAdvice({
   return callResponses<AdvicePayload>(
     {
       model,
+      modalities: ['text'],
       input: [
         {
           role: 'system',


### PR DESCRIPTION
## Summary
- derive the required `modalities` and JSON format options before calling the OpenAI Responses API so no legacy `response_format` flag is sent
- annotate the chart analysis and advice payloads with explicit text/vision modalities to match the documented schema when uploading screenshots

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d89dc00418832f8cb667f2c0749fee