### PR TITLE
Handle Alpha Vantage listing failures gracefully

### DIFF
--- a/app/api/analyze-photo/route.ts
+++ b/app/api/analyze-photo/route.ts
@@ -18,7 +18,12 @@ export async function POST(request: Request) {
     let universe: string[] = [];
 
     if (alphaApiKey) {
-      universe = await fetchListings(alphaApiKey);
+      try {
+        universe = await fetchListings(alphaApiKey);
+      } catch (error) {
+        console.error('Failed to load Alpha Vantage listings, continuing without universe', error);
+        universe = [];
+      }
     }
 
     if (hints?.symbolText) {


### PR DESCRIPTION
## Summary
- guard the Alpha Vantage listings lookup in the photo analysis API so failures no longer abort the request

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d8e75811cc832f8335dd078a58eb32