### PR TITLE
Remove binary capture fixture and inline data URL

### DIFF
--- a/app/(tabs)/capture/page.tsx
+++ b/app/(tabs)/capture/page.tsx
@@ -89,6 +89,12 @@ interface ChartPoint {
 export default function CapturePage() {
   const { settings, ready } = useAppSettings();
   const [preview, setPreview] = useState<string | null>(null);
+  const [previewMeta, setPreviewMeta] = useState<{
+    width: number;
+    height: number;
+    originalWidth: number;
+    originalHeight: number;
+  } | null>(null);
   const [analysis, setAnalysis] = useState<PhotoAnalysis | null>(null);
   const [score, setScore] = useState<ScoreResult | null>(null);
   const [advice, setAdvice] = useState<AdvicePayload | null>(null);
@@ -122,6 +128,7 @@ export default function CapturePage() {
       setAdvice(null);
       setChart([]);
       setSymbol(null);
+      setPreviewMeta(null);
       const defaultMonths = clampTimeframe(6);
       setTimeframeMonths(defaultMonths);
       setPriceScale('linear');
@@ -131,9 +138,16 @@ export default function CapturePage() {
 
       const processed = await processImageFile(file);
       setPreview(processed.dataUrl);
+      setPreviewMeta({
+        width: processed.width,
+        height: processed.height,
+        originalWidth: processed.originalWidth,
+        originalHeight: processed.originalHeight
+      });
     } catch (err) {
       console.error(err);
       setError('画像の処理中に問題が発生しました');
+      setPreviewMeta(null);
     }
   };
 
@@ -149,6 +163,7 @@ export default function CapturePage() {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           image: preview,
+          imageMeta: previewMeta ?? undefined,
           hints: analysis ? { timeframe: analysis.timeframe } : {},
           openAIApiKey: settings.openAIApiKey,
           alphaApiKey: settings.alphaVantageApiKey

--- a/app/api/analyze-photo/route.ts
+++ b/app/api/analyze-photo/route.ts
@@ -2,18 +2,36 @@ import { NextResponse } from 'next/server';
 import { analyzePhoto } from '@/lib/openai';
 import { fetchSymbolSearch, fetchListings } from '@/lib/alphavantage';
 import { reconcileSymbol } from '@/lib/reconcile';
-import type { PhotoAnalysis } from '@/lib/types';
 
 export const runtime = 'edge';
 
+const estimateDataUrlBytes = (value: string): number => {
+  if (!value.startsWith('data:')) {
+    return new TextEncoder().encode(value).length;
+  }
+  const base64Index = value.indexOf('base64,');
+  if (base64Index === -1) {
+    return new TextEncoder().encode(value).length;
+  }
+  const base64 = value.slice(base64Index + 'base64,'.length);
+  const padding = (base64.match(/=+$/)?.[0].length ?? 0);
+  return Math.max(0, Math.floor((base64.length * 3) / 4) - padding);
+};
+
 export async function POST(request: Request) {
   try {
-    const { image, hints, openAIApiKey, alphaApiKey } = await request.json();
+    const { image, hints, openAIApiKey, alphaApiKey, imageMeta } = await request.json();
     if (!image) {
       return NextResponse.json({ error: 'image is required' }, { status: 400 });
     }
 
-    const photoJson: PhotoAnalysis = await analyzePhoto({ image, hints, apiKey: openAIApiKey });
+    const startedAt = Date.now();
+    const { analysis: photoJson, responseId, usage } = await analyzePhoto({
+      image,
+      hints,
+      apiKey: openAIApiKey
+    });
+    const durationMs = Date.now() - startedAt;
     let resolved: string | null = null;
     let universe: string[] = [];
 
@@ -39,9 +57,27 @@ export async function POST(request: Request) {
       resolved = reconcileSymbol(photoJson, hints?.symbolText ?? null, universe);
     }
 
+    const bytes = estimateDataUrlBytes(image);
+    const kilobytes = bytes > 0 ? Math.round((bytes / 1024) * 10) / 10 : null;
+    console.info('analyze-photo completed', {
+      responseId,
+      durationMs,
+      image: {
+        width: imageMeta?.width ?? null,
+        height: imageMeta?.height ?? null,
+        originalWidth: imageMeta?.originalWidth ?? null,
+        originalHeight: imageMeta?.originalHeight ?? null,
+        kilobytes
+      },
+      usage
+    });
+
     return NextResponse.json({ photo: photoJson, resolvedSymbol: resolved });
   } catch (error) {
     console.error(error);
-    return NextResponse.json({ error: (error as Error).message }, { status: 500 });
+    const status = typeof (error as { status?: number }).status === 'number'
+      ? (error as { status?: number }).status!
+      : 500;
+    return NextResponse.json({ error: (error as Error).message }, { status });
   }
 }

--- a/lib/openai.ts
+++ b/lib/openai.ts
@@ -163,7 +163,10 @@ async function callResponses<T>(
 
   try {
     const response = await client.responses.create(finalPayload);
-    const output = response.output ?? response;
+    const output =
+      typeof response === 'object' && response !== null && 'output' in response
+        ? (response as { output?: unknown }).output ?? response
+        : response;
 
     const jsonPayload = findJsonPayload(output);
     if (jsonPayload !== undefined) {

--- a/lib/openai.ts
+++ b/lib/openai.ts
@@ -117,6 +117,7 @@ interface CallResponsesOptions {
 }
 type ResponsesCreateParams = Parameters<OpenAI['responses']['create']>[0];
 type OpenAIResponse = Awaited<ReturnType<OpenAI['responses']['create']>>;
+type OpenAIResponseUsage = OpenAIResponse extends { usage?: infer U } ? U : undefined;
 
 interface CallResponsesResult<T> {
   data: T;
@@ -235,7 +236,7 @@ async function callResponses<T>(
 export interface AnalyzePhotoResult {
   analysis: PhotoAnalysis;
   responseId: string;
-  usage?: OpenAIResponse['usage'];
+  usage?: OpenAIResponseUsage;
 }
 
 export async function analyzePhoto({
@@ -348,7 +349,7 @@ export async function analyzePhoto({
   return {
     analysis: data,
     responseId: response.id,
-    usage: response.usage
+    usage: 'usage' in response ? (response as { usage?: OpenAIResponseUsage }).usage : undefined
   };
 }
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test:capture": "node scripts/test-capture.mjs"
   },
   "dependencies": {
     "@headlessui/react": "^1.7.17",
@@ -14,6 +15,7 @@
     "clsx": "^2.1.1",
     "framer-motion": "^11.0.17",
     "next": "14.1.0",
+    "openai": "^4.57.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "swr": "^2.2.4"

--- a/scripts/test-capture.mjs
+++ b/scripts/test-capture.mjs
@@ -1,0 +1,63 @@
+const SAMPLE_IMAGE_DATA_URL =
+  'data:image/png;base64,' +
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/P33jjwAAAABJRU5ErkJggg==';
+
+const BASE_URL = process.env.CAPTURE_TEST_URL ?? 'http://localhost:3000';
+
+const describePayloadKeys = (payload) =>
+  Object.entries(payload).map(([key, value]) => `${key}:${typeof value}`);
+
+let lastPayloadKeys = null;
+
+async function main() {
+  const imageDataUrl = SAMPLE_IMAGE_DATA_URL;
+
+  const payload = {
+    image: imageDataUrl,
+    hints: {},
+    openAIApiKey: process.env.OPENAI_API_KEY ?? undefined
+  };
+  lastPayloadKeys = describePayloadKeys(payload);
+
+  const response = await fetch(`${BASE_URL}/api/analyze-photo`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload)
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    console.error('Request failed', response.status, text);
+    console.error('Payload keys', lastPayloadKeys);
+    process.exit(1);
+  }
+
+  const json = await response.json();
+  const photo = json.photo ?? {};
+
+  if (!photo.chart_type) {
+    throw new Error('chart_type is missing in photo analysis');
+  }
+  if (!photo.x_axis || typeof photo.x_axis.scale !== 'string' || typeof photo.x_axis.unit !== 'string') {
+    throw new Error('x_axis is missing scale/unit');
+  }
+  if (!photo.y_axis || typeof photo.y_axis.scale !== 'string' || typeof photo.y_axis.unit !== 'string') {
+    throw new Error('y_axis is missing scale/unit');
+  }
+
+  console.log('Capture test succeeded', {
+    chart_type: photo.chart_type,
+    x_axis: photo.x_axis,
+    y_axis: photo.y_axis
+  });
+
+  return lastPayloadKeys;
+}
+
+main().catch((error) => {
+  console.error('Capture test failed', error);
+  if (lastPayloadKeys) {
+    console.error('Payload keys', lastPayloadKeys);
+  }
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- replace the capture regression script's file-based image handling with an embedded data URL
- delete the unused public/test/chart.png asset that caused binary diffs

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8ead3de10832fac997ba20fa5e588