### PR TITLE
Improve assistant chat bubble contrast

### DIFF
--- a/components/ChatBubble.tsx
+++ b/components/ChatBubble.tsx
@@ -7,7 +7,7 @@ export function ChatBubble({ role, children }: { role: 'user' | 'assistant'; chi
       <div
         className={clsx(
           'max-w-[80%] rounded-2xl px-4 py-3 text-sm shadow-kachi',
-          isUser ? 'bg-kachi-accent text-kachi-shade' : 'bg-kachi-surface/90 text-kachi-textdark'
+          isUser ? 'bg-kachi-accent text-kachi-shade' : 'bg-kachi-surface text-kachi'
         )}
       >
         {children}


### PR DESCRIPTION
## Summary
- update the assistant chat bubble style to use the darker brand text color on a light surface background for improved contrast

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e609afee0c832f8659ec02b06c578a